### PR TITLE
Enhance utilities and add get_count tests

### DIFF
--- a/flarchitect/utils/core_utils.py
+++ b/flarchitect/utils/core_utils.py
@@ -1,3 +1,5 @@
+"""Core utility helpers for data manipulation."""
+
 import re
 from typing import Any
 
@@ -11,7 +13,8 @@ def convert_case(s: str, target_case: str) -> str:
     Args:
         s (str): The input string.
         target_case (str):
-            The target case format (camel, pascal, snake, screaming_snake, kebab, screaming_kebab).
+            The target case format (camel, pascal, snake,
+            screaming_snake, kebab, screaming_kebab).
 
     Returns:
         str: The converted string.
@@ -63,10 +66,16 @@ def convert_kebab_to_snake(kebab_str: str) -> str:
 
 
 def dict_to_xml(input_dict: dict) -> str:
-    # Convert dict to XML bytes
-    xml_bytes = dicttoxml(input_dict, custom_root="root", attr_type=False)
+    """Convert a dictionary to an XML string.
 
-    # Pretty print the XML string
+    Args:
+        input_dict: Dictionary to be converted.
+
+    Returns:
+        str: XML representation of ``input_dict``.
+    """
+
+    xml_bytes = dicttoxml(input_dict, custom_root="root", attr_type=False)
     return xml_bytes.decode()
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,6 +1,6 @@
 import pytest
 
-from flarchitect.utils.core_utils import convert_case, dict_to_xml
+from flarchitect.utils.core_utils import convert_case, dict_to_xml, get_count
 from flarchitect.utils.general import (
     pluralize_last_word,
     validate_flask_limiter_rate_limit_string,
@@ -9,7 +9,6 @@ from flarchitect.utils.general import (
 
 
 class TestValidateRateLimitString:
-
     #  Valid rate limit string with integer and "per" followed by allowed time unit
     def test_valid_rate_limit_string(self):
         # Arrange
@@ -36,11 +35,10 @@ class TestValidateRateLimitString:
         result = validate_flask_limiter_rate_limit_string(rate_limit_str)
 
         # Assert
-        assert result == False
+        assert not result
 
 
 class TestConvertCase:
-
     #  The function correctly converts a string to camelCase.
     def test_convert_to_camel_case(self):
         # Arrange
@@ -146,9 +144,7 @@ class TestConvertCase:
         assert result == expected_result
 
 
-
 class TestPluralizeLastWord:
-
     #  pluralizes last word in camelCase
     def test_pluralize_last_word_camel_case(self):
         # Arrange
@@ -193,7 +189,6 @@ class TestPluralizeLastWord:
         # Assert
         assert result == "SCREAMING_SNAKE_CASES"
 
-
     #  input with only one word returns the plural of that word
     def test_pluralize_last_word_single_word(self):
         # Arrange
@@ -209,52 +204,45 @@ class TestPluralizeLastWord:
 
 
 class TestXml:
-
     def test_simple_dict(self):
         # Arrange
-        input_dict = {
-            "person": {
-                "name": "John",
-                "age": 30
-            }
-        }
-        expected_xml = '<?xml version="1.0" encoding="UTF-8" ?><root><person><name>John</name><age>30</age></person></root>'
+        input_dict = {"person": {"name": "John", "age": 30}}
+        expected_xml = (
+            '<?xml version="1.0" encoding="UTF-8" ?>'
+            "<root><person><name>John</name><age>30</age></person></root>"
+        )
 
         # Act
         result = dict_to_xml(input_dict)
 
         # Assert
         assert result == expected_xml
-
 
     def test_nested_dict(self):
         # Arrange
         input_dict = {
-            "person": {
-                "name": "John",
-                "address": {
-                    "city": "New York",
-                    "zip": "10001"
-                }
-            }
+            "person": {"name": "John", "address": {"city": "New York", "zip": "10001"}}
         }
-        expected_xml = '<?xml version="1.0" encoding="UTF-8" ?><root><person><name>John</name><address><city>New York</city><zip>10001</zip></address></person></root>'
+        expected_xml = (
+            '<?xml version="1.0" encoding="UTF-8" ?>'
+            "<root><person><name>John</name><address><city>New York</city>"
+            "<zip>10001</zip></address></person></root>"
+        )
 
         # Act
         result = dict_to_xml(input_dict)
 
         # Assert
         assert result == expected_xml
-
 
     def test_list_in_dict(self):
         # Arrange
-        input_dict = {
-            "fruits": {
-                "fruit": ["apple", "banana", "cherry"]
-            }
-        }
-        expected_xml = '<?xml version="1.0" encoding="UTF-8" ?><root><fruits><fruit><item>apple</item><item>banana</item><item>cherry</item></fruit></fruits></root>'
+        input_dict = {"fruits": {"fruit": ["apple", "banana", "cherry"]}}
+        expected_xml = (
+            '<?xml version="1.0" encoding="UTF-8" ?>'
+            "<root><fruits><fruit><item>apple</item><item>banana</item>"
+            "<item>cherry</item></fruit></fruits></root>"
+        )
 
         # Act
         result = dict_to_xml(input_dict)
@@ -262,14 +250,13 @@ class TestXml:
         # Assert
         assert result == expected_xml
 
-
     def test_root_tag_for_multiple_keys(self):
         # Arrange
-        input_dict = {
-            "name": "John",
-            "age": 30
-        }
-        expected_xml = '<?xml version="1.0" encoding="UTF-8" ?><root><name>John</name><age>30</age></root>'
+        input_dict = {"name": "John", "age": 30}
+        expected_xml = (
+            '<?xml version="1.0" encoding="UTF-8" ?>'
+            "<root><name>John</name><age>30</age></root>"
+        )
 
         # Act
         result = dict_to_xml(input_dict)
@@ -281,32 +268,20 @@ class TestXml:
 class TestXmlDict:
     def test_simple_xml_to_dict(self):
         # Arrange
-        xml_data = """<?xml version='1.0' encoding='UTF-8' standalone='no'?><person><name>John</name><age>30</age></person>"""
-        expected_dict = {
-            "person": {
-                "name": "John",
-                "age": "30"
-            }
-        }
+        xml_data = """<?xml version='1.0' encoding='UTF-8' standalone='no'?><person><name>John</name><age>30</age></person>"""  # noqa: E501
+        expected_dict = {"person": {"name": "John", "age": "30"}}
 
         # Act
         result = xml_to_dict(xml_data)
 
         # Assert
         assert result == expected_dict
-
 
     def test_nested_xml_to_dict(self):
         # Arrange
-        xml_data = """<?xml version='1.0' encoding='UTF-8' standalone='no'?><person><name>John</name><address><city>New York</city><zip>10001</zip></address></person>"""
+        xml_data = """<?xml version='1.0' encoding='UTF-8' standalone='no'?><person><name>John</name><address><city>New York</city><zip>10001</zip></address></person>"""  # noqa: E501
         expected_dict = {
-            "person": {
-                "name": "John",
-                "address": {
-                    "city": "New York",
-                    "zip": "10001"
-                }
-            }
+            "person": {"name": "John", "address": {"city": "New York", "zip": "10001"}}
         }
 
         # Act
@@ -314,34 +289,22 @@ class TestXmlDict:
 
         # Assert
         assert result == expected_dict
-
 
     def test_xml_with_list_to_dict(self):
         # Arrange
-        xml_data = """<?xml version='1.0' encoding='UTF-8' standalone='no'?><fruits><fruit>apple</fruit><fruit>banana</fruit><fruit>cherry</fruit></fruits>"""
-        expected_dict = {
-            "fruits": {
-                "fruit": ["apple", "banana", "cherry"]
-            }
-        }
+        xml_data = """<?xml version='1.0' encoding='UTF-8' standalone='no'?><fruits><fruit>apple</fruit><fruit>banana</fruit><fruit>cherry</fruit></fruits>"""  # noqa: E501
+        expected_dict = {"fruits": {"fruit": ["apple", "banana", "cherry"]}}
 
         # Act
         result = xml_to_dict(xml_data)
 
         # Assert
         assert result == expected_dict
-
 
     def test_xml_with_empty_elements(self):
         # Arrange
-        xml_data = """<?xml version='1.0' encoding='UTF-8' standalone='no'?><person><name>John</name><nickname/><age>30</age></person>"""
-        expected_dict = {
-            "person": {
-                "name": "John",
-                "nickname": None,
-                "age": "30"
-            }
-        }
+        xml_data = """<?xml version='1.0' encoding='UTF-8' standalone='no'?><person><name>John</name><nickname/><age>30</age></person>"""  # noqa: E501
+        expected_dict = {"person": {"name": "John", "nickname": None, "age": "30"}}
 
         # Act
         result = xml_to_dict(xml_data)
@@ -349,28 +312,49 @@ class TestXmlDict:
         # Assert
         assert result == expected_dict
 
-
     def test_invalid_xml(self):
         # Arrange
-        invalid_xml = """<person><name>John</name><age>30</person>"""  # Malformed XML (unmatched tags)
+        invalid_xml = """<person><name>John</name><age>30</person>"""  # Malformed XML (unmatched tags)  # noqa: E501
 
         # Act & Assert
         with pytest.raises(ValueError, match="Invalid XML data provided"):
             xml_to_dict(invalid_xml)
 
-
     def test_bytes_input_xml(self):
         # Arrange
-        xml_data = b"""<?xml version='1.0' encoding='UTF-8' standalone='no'?><person><name>John</name><age>30</age></person>"""
-        expected_dict = {
-            "person": {
-                "name": "John",
-                "age": "30"
-            }
-        }
+        xml_data = b"""<?xml version='1.0' encoding='UTF-8' standalone='no'?><person><name>John</name><age>30</age></person>"""  # noqa: E501
+        expected_dict = {"person": {"name": "John", "age": "30"}}
 
         # Act
         result = xml_to_dict(xml_data)
 
         # Assert
         assert result == expected_dict
+
+
+class TestGetCount:
+    """Tests for :func:`flarchitect.utils.core_utils.get_count`."""
+
+    def test_prefers_total_count(self):
+        """Return value from ``total_count`` when present."""
+
+        result = {"total_count": 5}
+        assert get_count(result, [1, 2]) == 5
+
+    def test_list_value(self):
+        """Return length of list when ``total_count`` absent."""
+
+        result: dict[str, int] = {}
+        assert get_count(result, [1, 2, 3]) == 3
+
+    def test_single_value(self):
+        """Return ``1`` for a non-list truthy value."""
+
+        result: dict[str, int] = {}
+        assert get_count(result, {"a": 1}) == 1
+
+    def test_no_value(self):
+        """Return ``0`` when value is falsy."""
+
+        result: dict[str, int] = {}
+        assert get_count(result, None) == 0


### PR DESCRIPTION
## Summary
- add missing imports and docstrings in core and general utilities
- validate service dependencies using `importlib.util` and improve HTML lookup docstring
- cover `get_count` scenarios with new unit tests

## Testing
- `ruff format flarchitect/utils/core_utils.py flarchitect/utils/general.py tests/test_functions.py`
- `ruff check flarchitect/utils/core_utils.py flarchitect/utils/general.py tests/test_functions.py`
- `pytest tests/test_functions.py::TestGetCount -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b117197c83229ace12b27d6eaa9b