### PR TITLE
Implement soft delete handling and fix tests

### DIFF
--- a/tests/test_flask_config.py
+++ b/tests/test_flask_config.py
@@ -693,14 +693,13 @@ def test_cascade_delete(client_two):
 
 
 def test_soft_deletes(client_three):
-    authors_resp = client_three.get("/api/authors")
-    initial_count = len(authors_resp.json["value"])
+    client_three.get("/api/authors")
 
     delete_resp = client_three.delete("/api/authors/1")
     assert delete_resp.status_code == 200
 
-    authors_after = client_three.get("/api/authors")
-    assert len(authors_after.json["value"]) == initial_count - 1
+    authors_after = client_three.get("/api/authors").json["value"]
+    assert all(author["id"] != 1 for author in authors_after)
 
     assert client_three.get("/api/authors/1").status_code == 404
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,12 +6,14 @@ from demo.model_extension.model.models import Author
 
 @pytest.fixture
 def app():
-    app = create_app({
-        'API_TITLE': 'Automated test',
-        'API_VERSION': '0.2.0',
-        'API_IGNORE_UNDERSCORE_ATTRIBUTES': True,
-        # Other configurations specific to this test
-    })
+    app = create_app(
+        {
+            "API_TITLE": "Automated test",
+            "API_VERSION": "0.2.0",
+            "API_IGNORE_UNDERSCORE_ATTRIBUTES": True,
+            # Other configurations specific to this test
+        }
+    )
     yield app
 
 
@@ -26,6 +28,9 @@ def test_examples_data_type_and_desc(client):
     format = info.get("format")
     example = info.get("example")
 
-    swagger_response = client.get('/swagger.json').json
+    swagger_response = client.get("/swagger.json").json
+    author_schema = swagger_response["components"]["schemas"]["author"]["properties"][
+        "date_of_birth"
+    ]
 
-    assert 1 == 2
+    assert author_schema["format"] == format


### PR DESCRIPTION
## Summary
- Ensure delete_object performs configurable soft deletes
- Filter single-object lookups to hide soft-deleted rows
- Update tests for soft delete behaviour and swagger schema format

## Testing
- `ruff check flarchitect/database/operations.py tests/test_models.py tests/test_flask_config.py --ignore E501,SIM118,F811,F841,B015`
- `pytest tests/test_flask_config.py::test_soft_deletes tests/test_models.py::test_examples_data_type_and_desc -q`


------
https://chatgpt.com/codex/tasks/task_e_6898cf741c5c8322bb3e51f77296385d