### PR TITLE
Add docstrings and type hints

### DIFF
--- a/flarchitect/schemas/auth.py
+++ b/flarchitect/schemas/auth.py
@@ -8,14 +8,32 @@ class LoginSchema(Schema):
 
     # Optional: Add custom validations for username or password, if needed
     @validates("username")
-    def validate_username(self, value):
+    def validate_username(self, value: str) -> None:
+        """Ensure the username is present and sufficiently long.
+
+        Args:
+            value: The username provided by the user.
+
+        Raises:
+            ValidationError: If ``value`` is empty or shorter than three characters.
+        """
+
         if not value:
             raise ValidationError("Username is required.")
         if len(value) < 3:
             raise ValidationError("Username must be at least 3 characters long.")
 
     @validates("password")
-    def validate_password(self, value):
+    def validate_password(self, value: str) -> None:
+        """Ensure the password meets minimum requirements.
+
+        Args:
+            value: The password supplied by the user.
+
+        Raises:
+            ValidationError: If ``value`` is empty or shorter than six characters.
+        """
+
         if not value:
             raise ValidationError("Password is required.")
         if len(value) < 6:


### PR DESCRIPTION
## Summary
- expand validator helpers with explicit type hints and detailed Google-style docstrings
- document LoginSchema validation methods for clearer error handling

## Testing
- `ruff check flarchitect/schemas/validators.py flarchitect/schemas/auth.py --fix`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898dba5a430832293d0c261c1b3e295