### PR TITLE
docs: add authentication examples

### DIFF
--- a/demo/authentication/README.md
+++ b/demo/authentication/README.md
@@ -78,3 +78,14 @@ With these steps completed, run your application and navigate to the `/docs` rou
 
 This refined approach clarifies the setup process, emphasizing essential steps and configurations for
 integrating `flarchitect` into your Flask application.
+
+## Authentication Examples
+
+The `demo/authentication` directory contains runnable snippets for each built-in authentication strategy:
+
+- `jwt_auth.py` – JSON Web Token authentication
+- `basic_auth.py` – HTTP Basic authentication
+- `api_key_auth.py` – API key authentication
+- `custom_auth.py` – Custom callable authentication
+
+All examples share a common setup defined in `app_base.py`.

--- a/demo/authentication/api_key_auth.py
+++ b/demo/authentication/api_key_auth.py
@@ -1,0 +1,32 @@
+"""API key authentication example."""
+
+from __future__ import annotations
+
+from demo.authentication.app_base import BaseConfig, User, create_app, schema
+from flarchitect.authentication.user import get_current_user, set_current_user
+
+
+def lookup_user_by_token(token: str) -> User | None:
+    """Return a user matching ``token``."""
+
+    user = User.query.filter_by(api_key=token).first()
+    if user:
+        set_current_user(user)
+    return user
+
+
+class Config(BaseConfig):
+    API_AUTHENTICATE_METHOD = ["api_key"]
+    API_KEY_AUTH_AND_RETURN_METHOD = staticmethod(lookup_user_by_token)
+
+
+app = create_app(Config)
+
+
+@app.get("/profile")
+@schema.route(model=User)
+def profile() -> dict[str, str]:
+    """Return the current user's profile."""
+
+    user = get_current_user()
+    return {"username": user.username}

--- a/demo/authentication/app_base.py
+++ b/demo/authentication/app_base.py
@@ -1,0 +1,64 @@
+"""Common application setup used across authentication demos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from flarchitect.core.architect import Architect
+
+
+class BaseModel(DeclarativeBase):
+    """Base SQLAlchemy model with a :func:`get_session` helper."""
+
+    def get_session(*args):  # type: ignore[no-untyped-def]
+        """Return the active database session."""
+        return db.session
+
+
+db = SQLAlchemy(model_class=BaseModel)
+schema = Architect()
+
+
+class User(db.Model):
+    """Very small user model for authentication examples."""
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str] = mapped_column(unique=True)
+    password: Mapped[str] = mapped_column()
+    api_key: Mapped[str | None] = mapped_column(nullable=True)
+
+    def check_password(self, candidate: str) -> bool:
+        """Compare stored password with ``candidate``.
+
+        Password hashing is intentionally omitted to keep the example focused on
+        authentication wiring rather than security implementation details.
+        """
+
+        return self.password == candidate
+
+
+@dataclass
+class BaseConfig:
+    """Base configuration shared by all authentication examples."""
+
+    SQLALCHEMY_DATABASE_URI: str = "sqlite:///:memory:"
+    SQLALCHEMY_TRACK_MODIFICATIONS: bool = False
+    API_BASE_MODEL = db.Model
+    API_TITLE: str = "Book Shop API"
+    API_VERSION: str = "0.1.0"
+    API_VERBOSITY_LEVEL: int = 4
+    SECRET_KEY: str = "change-me"
+
+
+def create_app(config: type[BaseConfig]) -> Flask:
+    """Application factory used by the example modules."""
+
+    app = Flask(__name__)
+    app.config.from_object(config)
+    db.init_app(app)
+    schema.init_app(app)
+    return app

--- a/demo/authentication/basic_auth.py
+++ b/demo/authentication/basic_auth.py
@@ -1,0 +1,25 @@
+"""HTTP Basic authentication example."""
+
+from __future__ import annotations
+
+from demo.authentication.app_base import BaseConfig, User, create_app, schema
+from flarchitect.authentication.user import get_current_user
+
+
+class Config(BaseConfig):
+    API_AUTHENTICATE_METHOD = ["basic"]
+    API_USER_MODEL = User
+    API_USER_LOOKUP_FIELD = "username"
+    API_CREDENTIAL_CHECK_METHOD = "check_password"
+
+
+app = create_app(Config)
+
+
+@app.get("/profile")
+@schema.route(model=User)
+def profile() -> dict[str, str]:
+    """Return the current user's profile."""
+
+    user = get_current_user()
+    return {"username": user.username}

--- a/demo/authentication/custom_auth.py
+++ b/demo/authentication/custom_auth.py
@@ -1,0 +1,36 @@
+"""Custom authentication example."""
+
+from __future__ import annotations
+
+from flask import request
+
+from demo.authentication.app_base import BaseConfig, User, create_app, schema
+from flarchitect.authentication.user import get_current_user, set_current_user
+
+
+def custom_auth() -> bool:
+    """Authenticate based on an ``X-Token`` header."""
+
+    token = request.headers.get("X-Token", "")
+    user = User.query.filter_by(api_key=token).first()
+    if user:
+        set_current_user(user)
+        return True
+    return False
+
+
+class Config(BaseConfig):
+    API_AUTHENTICATE_METHOD = ["custom"]
+    API_CUSTOM_AUTH = staticmethod(custom_auth)
+
+
+app = create_app(Config)
+
+
+@app.get("/profile")
+@schema.route(model=User)
+def profile() -> dict[str, str]:
+    """Return the current user's profile."""
+
+    user = get_current_user()
+    return {"username": user.username}

--- a/demo/authentication/jwt_auth.py
+++ b/demo/authentication/jwt_auth.py
@@ -1,0 +1,46 @@
+"""JWT authentication example."""
+
+from __future__ import annotations
+
+from flask import request
+
+from demo.authentication.app_base import BaseConfig, User, create_app, schema
+from flarchitect.authentication.jwt import generate_access_token, generate_refresh_token
+from flarchitect.authentication.user import get_current_user
+from flarchitect.exceptions import CustomHTTPException
+
+
+class Config(BaseConfig):
+    API_AUTHENTICATE_METHOD = ["jwt"]
+    ACCESS_SECRET_KEY = "access-secret"
+    REFRESH_SECRET_KEY = "refresh-secret"
+    API_USER_MODEL = User
+    API_USER_LOOKUP_FIELD = "username"
+    API_CREDENTIAL_CHECK_METHOD = "check_password"
+
+
+app = create_app(Config)
+
+
+@app.post("/auth/login")
+@schema.route(model=User, auth=False)
+def login() -> dict[str, str]:
+    """Authenticate the user and issue JWT tokens."""
+
+    data = request.get_json() or {}
+    user = User.query.filter_by(username=data.get("username")).first()
+    if not user or not user.check_password(data.get("password", "")):
+        raise CustomHTTPException(status_code=401)
+    return {
+        "access_token": generate_access_token(user),
+        "refresh_token": generate_refresh_token(user),
+    }
+
+
+@app.get("/profile")
+@schema.route(model=User)
+def profile() -> dict[str, str]:
+    """Return the current user's profile."""
+
+    user = get_current_user()
+    return {"username": user.username}

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -1,11 +1,84 @@
 Authentication
 =========================================
 
-flarchitect ships with simple JWT helpers so you can secure your API quickly.
+flarchitect ships with multiple authentication helpers so you can secure your
+API quickly. Enable one or more strategies via the ``API_AUTHENTICATE_METHOD``
+configuration value. The available methods are ``jwt``, ``basic``, ``api_key``
+and ``custom``. Each example below shares a common setup defined in
+``demo/authentication/app_base.py``.
 
-* ``generate_access_token`` and ``generate_refresh_token`` create tokens for your users.
-* ``refresh_access_token`` issues a new access token when the old one expires.
-* ``jwt_authentication`` decorator validates incoming tokens and populates the current user.
+JWT tokens
+----------
 
-Tokens require ``ACCESS_SECRET_KEY`` and ``REFRESH_SECRET_KEY`` to be set and a user model specified via configuration.
-Check the demo application for a complete example.
+Requires ``ACCESS_SECRET_KEY`` and ``REFRESH_SECRET_KEY`` as well as a user
+model. A minimal configuration looks like:
+
+.. code-block:: python
+
+   class Config(BaseConfig):
+       API_AUTHENTICATE_METHOD = ["jwt"]
+       ACCESS_SECRET_KEY = "access-secret"
+       REFRESH_SECRET_KEY = "refresh-secret"
+       API_USER_MODEL = User
+       API_USER_LOOKUP_FIELD = "username"
+       API_CREDENTIAL_CHECK_METHOD = "check_password"
+
+See ``demo/authentication/jwt_auth.py`` for a full example including a login
+endpoint.
+
+Basic authentication
+--------------------
+
+Provide a lookup field and password check method on your user model:
+
+.. code-block:: python
+
+   class Config(BaseConfig):
+       API_AUTHENTICATE_METHOD = ["basic"]
+       API_USER_MODEL = User
+       API_USER_LOOKUP_FIELD = "username"
+       API_CREDENTIAL_CHECK_METHOD = "check_password"
+
+A runnable snippet lives at ``demo/authentication/basic_auth.py``.
+
+API key authentication
+----------------------
+
+Attach a function that accepts an API key and returns a user. The function can
+also call ``set_current_user``:
+
+.. code-block:: python
+
+   def lookup_user_by_token(token: str) -> User | None:
+       user = User.query.filter_by(api_key=token).first()
+       if user:
+           set_current_user(user)
+       return user
+
+   class Config(BaseConfig):
+       API_AUTHENTICATE_METHOD = ["api_key"]
+       API_KEY_AUTH_AND_RETURN_METHOD = staticmethod(lookup_user_by_token)
+
+See ``demo/authentication/api_key_auth.py`` for more detail.
+
+Custom authentication
+---------------------
+
+For complete control supply your own callable:
+
+.. code-block:: python
+
+   def custom_auth() -> bool:
+       token = request.headers.get("X-Token", "")
+       user = User.query.filter_by(api_key=token).first()
+       if user:
+           set_current_user(user)
+           return True
+       return False
+
+   class Config(BaseConfig):
+       API_AUTHENTICATE_METHOD = ["custom"]
+       API_CUSTOM_AUTH = staticmethod(custom_auth)
+
+The ``demo/authentication/custom_auth.py`` module shows this approach in
+context.


### PR DESCRIPTION
## Summary
- add shared demo app and user model for authentication examples
- demonstrate JWT, basic, API key, and custom authentication
- document all four authentication methods and reference new examples

## Testing
- `ruff check --fix demo/authentication/app_base.py demo/authentication/jwt_auth.py demo/authentication/basic_auth.py demo/authentication/api_key_auth.py demo/authentication/custom_auth.py`
- `pytest tests/test_authentication.py tests/test_basic.py -q -W ignore::DeprecationWarning -W ignore::UserWarning`
- `sphinx-build -b html docs/source docs/build/html`

------
https://chatgpt.com/codex/tasks/task_e_68997c547a788322aa296743f1b3419e