### PR TITLE
Improve authentication and callbacks documentation

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -1,16 +1,15 @@
 Authentication
 =========================================
 
-flarchitect ships with multiple authentication helpers so you can secure your
-API quickly. Enable one or more strategies via the ``API_AUTHENTICATE_METHOD``
-configuration value. The available methods are ``jwt``, ``basic``, ``api_key``
-and ``custom``. Each example below shares a common setup defined in
-``demo/authentication/app_base.py``.
+flarchitect provides several helpers so you can secure your API quickly.
+Enable one or more strategies via ``API_AUTHENTICATE_METHOD``. Available
+methods are ``jwt``, ``basic``, ``api_key`` and ``custom``. Each example below
+uses the common setup defined in ``demo/authentication/app_base.py``.
 
-JWT tokens
-----------
+JWT authentication
+------------------
 
-Requires ``ACCESS_SECRET_KEY`` and ``REFRESH_SECRET_KEY`` as well as a user
+JWT auth requires ``ACCESS_SECRET_KEY``, ``REFRESH_SECRET_KEY`` and a user
 model. A minimal configuration looks like:
 
 .. code-block:: python
@@ -23,7 +22,7 @@ model. A minimal configuration looks like:
        API_USER_LOOKUP_FIELD = "username"
        API_CREDENTIAL_CHECK_METHOD = "check_password"
 
-See ``demo/authentication/jwt_auth.py`` for a full example including a login
+See ``demo/authentication/jwt_auth.py`` for a complete example with a login
 endpoint.
 
 Basic authentication
@@ -39,7 +38,7 @@ Provide a lookup field and password check method on your user model:
        API_USER_LOOKUP_FIELD = "username"
        API_CREDENTIAL_CHECK_METHOD = "check_password"
 
-A runnable snippet lives at ``demo/authentication/basic_auth.py``.
+See ``demo/authentication/basic_auth.py`` for a runnable snippet.
 
 API key authentication
 ----------------------
@@ -80,5 +79,4 @@ For complete control supply your own callable:
        API_AUTHENTICATE_METHOD = ["custom"]
        API_CUSTOM_AUTH = staticmethod(custom_auth)
 
-The ``demo/authentication/custom_auth.py`` module shows this approach in
-context.
+See ``demo/authentication/custom_auth.py`` for this approach in context.

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -1,380 +1,156 @@
 Callbacks
 =========================================
 
-While accessing and updating your models via the API **flask-schema** has created is great. Sometimes you need to
-perform some additional logic before or after a model is returned, created, updated, deleted or if an error is raised.
+Callbacks let you hook into the request lifecycle to run custom logic around
+database operations and responses. They can be declared globally in the Flask
+configuration or on individual SQLAlchemy models.
 
-You might need to log API calls in the database, or send out an email when an error is raised. Possibly you need to
-perform some additional validation on the data before it is saved to the database.
+Lifecycle
+---------
 
-**flask-schema** provides a way to do this by defining callbacks on your `SQLAlchemy`_ models or `Flask`_ configuration.
+flarchitect recognizes four callback types:
 
-Callback Lifecycle
----------------------
+* **Setup** – runs before any database operation. Use for validation, logging
+  or altering the incoming data.
+* **Return** – runs after the operation but before the response is sent.
+  Ideal for adjusting the output or adding headers.
+* **Error** – runs when an exception bubbles up. Handle logging or
+  notifications here.
+* **Final** – runs immediately before the response is returned to the client.
 
-Callbacks can fire at 3 different points in the API request lifecycle.
+Configuration
+-------------
 
-1. **Setup Callback** - This is called before any database operation is executed. This could be used to perform any
-   additional validation or logging before the database operation is executed.
+Callbacks are referenced by the following configuration keys:
 
-2. **Return Callback** - This is called before flask route is returned. Here you could intercept the
-   response and perform any additional logic before the response is returned to the client.
+* ``SETUP_CALLBACK``
+* ``RETURN_CALLBACK``
+* ``ERROR_CALLBACK``
 
-3. **Error Callback** - This is called when an exception is raised. This could be used to log the error, send an email
-   or perform any additional logic when an exception is raised.
+You can apply these keys in several places:
 
-4. **Final Callback** - Called just before the API returns the the client.
+1. **Global Flask config**
 
-Configuring Callbacks
----------------------------
+   Use ``API_<KEY>`` to apply a callback to all endpoints.
 
-**flask-schema** uses the `Flask`_ configuration to define global configuration values and these same configuration
-values can be applied to specific `HTTP method`_'s or `SQLAlchemy`_ models.
+   .. code-block:: python
 
-.. note:: For comprehensive details on configuration, and where they can be applied visit our :doc:`configuration </configuration>` page.
+      class Config:
+          API_SETUP_CALLBACK = my_setup
 
-Configuration Keys
-^^^^^^^^^^^^^^^^^^^^^
+2. **HTTP method specific config**
 
+   Override the global value for a specific method with ``API_<METHOD>_<KEY>``.
 
+   .. code-block:: python
 
+      class Config:
+          API_GET_RETURN_CALLBACK = my_get_return
 
-`SETUP_CALLBACK <configuration.html#SETUP_CALLBACK>`_
-    Called before the database operation is executed.
+3. **Model config**
 
-    Can be set in the `Flask`_ configuration or in `SQLAlchemy`_ models.
+   Set lowercase attributes on a model's ``Meta`` class to apply callbacks to
+   all endpoints for that model.
 
-`RETURN_CALLBACK <configuration.html#RETURN_CALLBACK>`_
-    Called before the completed API response is returned.
+   .. code-block:: python
 
-    Can be set in the `Flask`_ configuration or in `SQLAlchemy`_ models.
+      class Author(db.Model):
+          class Meta:
+              setup_callback = my_setup
 
-`ERROR_CALLBACK <configuration.html#ERROR_CALLBACK>`_
-    Called when an exception is raised.
+4. **Model method config**
 
-    Can only be set in the `Flask`_ configuration, not in models.
+   Use ``<method>_<key>`` on the ``Meta`` class for the highest level of
+   specificity.
 
-Configuration Placement
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   .. code-block:: python
 
-.. dropdown:: Flask Global Configuration
+      class Author(db.Model):
+          class Meta:
+              get_return_callback = my_get_return
 
+Callback signatures
+-------------------
 
-    These configuration values can be set in your `Flask`_ configuration and will apply to all endpoints unless a more
-    specific value is set.
+``Setup`` and ``return`` callbacks should accept ``**kwargs`` and return the
+modified kwargs. Example:
 
-        Using the structure of ``API_{configuration_key}``
-
-        i.e  API_SETUP_CALLBACK = my_setup_callback
-
-    - `API_SETUP_CALLBACK <configuration.html#SETUP_CALLBACK>`_ - ``callable`` object to be executed before any database operation is executed.
-    - `API_RETURN_CALLBACK <configuration.html#RETURN_CALLBACK>`_ - ``callable`` object to be executed before the completed API response is returned.
-    - `API_ERROR_CALLBACK <configuration.html#ERROR_CALLBACK>`_ - ``callable`` object to be executed when an exception is raised.
-
-.. dropdown:: Flask Method Based Configuration
-
-
-    These methods will override any global configuration values for the specific `HTTP method`_ and are set in your `Flask`_
-    configuration.
-
-        Using the structure of ``API_{method}_{configuration_key}``
-
-        i.e  API_GET_SETUP_CALLBACK = my_get_setup_callback
-
-    - `API_GET_SETUP_CALLBACK <configuration.html#SETUP_CALLBACK>`_ - ``callable`` object to be executed before any `GET` database operation is executed.
-    - `API_POST_RETURN_CALLBACK <configuration.html#RETURN_CALLBACK>`_ - ``callable`` object to be executed before a completed `POST` API response is returned.
-    - `API_DELETE_ERROR_CALLBACK <configuration.html#ERROR_CALLBACK>`_ - ``callable`` object to be executed when a `DELETE` API call has an exception raised.
-
-.. dropdown:: SQLAlchemy Model Configuration
-
-
-    These override any of the previous configuration values, only overridden by method based model configuration. These
-    functions will apply to ANY endpoint for the model.
-
-        Using the structure of ``{configuration_key}`` in lower case.
-
-        Applied to the ``Meta`` class of the model.
-
-    i.e
-
-    .. code:: python
-
-        class MyModel(db.Model):
-            class Meta:
-                setup_callback = my_setup_callback
-
-    Example Configuration Values:
-
-    - `setup_callback <configuration.html#SETUP_CALLBACK>`_ - ``callable`` object to be executed before database operation is executed on the model.
-    - `return_callback <configuration.html#RETURN_CALLBACK>`_ - ``callable`` object to be executed before a completed request for this model is returned by the API.
-    - `error_callback <configuration.html#ERROR_CALLBACK>`_ - ``callable`` object to be executed when a API call has an exception raised for this models endpoint.
-
-
-.. dropdown:: SQLAlchemy Model Method Based Configuration
-
-    These take the highest priority and will override all other configuration values, and are set directly in the models
-
-        Using the structure of ``{method}_{configuration_key}`` in lower case.
-
-        Applied to the ``Meta`` class of the model.
-
-    i.e
-
-    .. code:: python
-
-        class MyModel(db.Model):
-            class Meta:
-                get_setup_callback = my_get_setup_callback
-                post_error_callback = my_post_error_callback
-
-    Example Configuration Values:
-
-    - `get_setup_callback <configuration.html#SETUP_CALLBACK>`_ - ``callable`` object to be executed before any `GET` database operation is executed on the model.
-    - `post_return_callback <configuration.html#RETURN_CALLBACK>`_ - ``callable`` object to be executed before a completed `POST` request for this model is returned by the API.
-    - `delete_error_callback <configuration.html#ERROR_CALLBACK>`_ - ``callable`` object to be executed when a `DELETE` API call has an exception raised for this model's endpoint.
-
-
-Callback Examples
---------------------------
-
-To demonstrate how to use callbacks, please see the demo folder of our `repo`_ or view the demo code `here <https://github.com/arched-dev/flarchitect/tree/master/demo/callbacks>`_.
-
-
-
-Callback Signatures
---------------------------
-
-It's probably best for your callback functions to accept `**kwargs` as the only argument. This will allow you to access
-any data you need from the request, response or error.
-
-A selection of data is passed to the callback functions (where possible), and this can differ depending on the
-`HTTP method`_ or lifecycle position. *It's also possible the structure of this data could change in later versions.*
-
-
-Setup callback signature
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The setup callback function's kwargs will accept data that could be needed to process the request.
-
-.. code:: python
-
-    {'model': "<class 'demo.model_extension.model.models.Author'>", 'id': 1, 'field': None, 'join_model': None, 'many': False, 'url': '/authors', 'name': 'author', 'output_schema': "<class 'abc.AuthorSchema'>", 'session': "<sqlalchemy.orm.scoping.scoped_session object at 0x7fbde078ae10>", 'input_schema': None, 'group_tag': 'People/Companies'}
-
-The setup function should return the `kwargs` object with any changes made to the data.
-
-.. code:: python
+.. code-block:: python
 
     def my_setup_callback(**kwargs):
-        # Do some logic here
+        # modify kwargs as needed
         return kwargs
 
+Error callbacks receive the exception and traceback:
 
-Return callback signature
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code-block:: python
 
+    def my_error_callback(exc, tb):
+        log_exception(exc, tb)
 
-The return callback function's kwargs will house the data that will be returned to the client. This may be the `SQLAlchemy`_
-query object or a dictionary of data depending on the query made.
+Post dump callbacks accept ``data`` and ``**kwargs`` and must return the data:
 
-.. code:: python
+.. code-block:: python
 
-    {'model': "<class 'demo.model_extension.model.models.Book'>", 'output': {'query': "<Book 137>"}, 'id': None, 'field': None, 'join_model': None, 'deserialized_data': {'title': 'The Crimson Beacon', 'isbn': '9782227215', 'publication_date': "datetime.date(2024, 4, 19)", 'author_id': 1, 'publisher_id': 12}}
-
-The return function should return the `kwargs` object with any changes made to the data.
-
-.. code:: python
-
-    def my_return_callback(**kwargs):
-        # Do some logic here
-        return kwargs
-
-
-
-Post dump callback signature
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-The post dump callback function accepts two arguments, the data (the serialized model in ``dict`` form) and ``**kwargs``
-passed to the schemas dump method.
-
-You must return the data after any changes have been made or the api will return ``None``.
-
-
-.. code:: python
-
-    def my_dump_function_callback(data, **kwargs):
-        if data.get("name") == "John":
-            data["name"] = "Johnathon"
+    def my_dump_callback(data, **kwargs):
+        data["name"] = data["name"].upper()
         return data
 
+Extending query parameters
+--------------------------
 
-.. code:: python
+Use ``ADDITIONAL_QUERY_PARAMS`` to document extra query parameters introduced in
+a return callback. The value is a list of OpenAPI parameter objects.
 
-    def my_dump_function_callback(data, **kwargs):
-        if not validate.email(data.get("email")):
-            raise CustomHTTPException(400, "Invalid email")
-        return data
-
-
-
-Error callback signature
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-The error callback function accepts the exception and traceback as arguments. There is no need to return anything.
-
-.. code:: python
-
-    def error_callback(e, traceback):
-        # Do some logic here
-
-
-
-Custom Exceptions
----------------------------
-
-Raising a custom exception in your callback will cause the API to return a custom error response. This can be useful
-for following the same error response structure as the rest of your API.
-
-This is simple and can be achieved with the custom exception class provided by **flask-schema**.
-
-.. code:: python
-
-    from flask_schema import CustomHTTPException
-
-    def my_error_callback(**kwargs):
-        raise CustomHTTPException(400, "My custom error message")
-
-    class MyModel(db.Model):
-        class Meta:
-            error_callback = my_error_callback
-
-
-Extending Query Params
----------------------------
-
-If you are hoping to extend a endpoints by adding additional ``query params`` to your endpoints defining the function is
-beyond the scope of ``flarchitect``.
-
-.. note::
-    If you are looking to add aditional filters...
-
-    The `return callback <configuration.html#RETURN_CALLBACK>`_ is the best place to handle this, as it will have
-    access to the `SQLAlchemy`_ ``Query`` object when in the kwargs passed to the function.
-
-    From here you can quite easily add additional filters.
-
-    .. code:: python
-
-        def my_return_callback(**kwargs):
-            query = kwargs.get("output")
-            query = query.filter_by(my_field=kwargs.get("my_query_param"))
-            kwargs["output"] = query
-            return kwargs
-
-However, you'll like want to document any changes to the available query params in `Redoc`_. This can be achieved with the
-`ADDITIONAL_QUERY_PARAMS <configuration.html#ADDITIONAL_QUERY_PARAMS>`_ configuration key.
-
-This key can be set in the `Flask`_ configuration or in `SQLAlchemy`_ models (globally or by `Http method`_).
-This means you can apply new query params to specific models, or across the API as a whole.
-
-The expected value is a ``list[dict]`` of the query params you want to add to the endpoint. Please use the below code
-examples as a guide for the expected structure.
-
-Consider the below example where we add a new query param to the `Flask`_ configuration (which is applied globally) to
-every model and endpoint in the documentation.
-
-.. code:: python
+.. code-block:: python
 
     class Config:
-
         API_ADDITIONAL_QUERY_PARAMS = [{
             "name": "log",
             "in": "query",
-            "description": "Log call into the database", # optional
-            "required": False, # optional
-            "deprecated": False, # optional
-            "schema": {
-                "type": "string", # see below for options available
-                "format": "password", # see below for options available ... optional
-                "example": 1  # optional
-            }
+            "description": "Log call into the database",
+            "schema": {"type": "string"},
         }]
-
-
-Or set to a specific `HTTP method`_ - ``GET`` on the model level.
-
-.. code:: python
 
     class Author(db.Model):
         class Meta:
             get_additional_query_params = [{
-                    "name": "log",
-                    "in": "query",
-                    "description": "Log call into the database", # optional
-                    "required": False, # optional
-                    "deprecated": False, # optional
-                    "schema": {
-                        "type": "string", # see below for options available
-                        "format": "password", # see below for options available ... optional
-                        "example": 1  # optional
-                    }
-                }]
+                "name": "log",
+                "in": "query",
+                "schema": {"type": "string"},
+            }]
 
+Acceptable types
+----------------
 
-Acceptable Types
-^^^^^^^^^^^^^^^^^^
+``schema.type`` may be one of:
 
-Below is a list of acceptable types for the `schema` key in the `ADDITIONAL_QUERY_PARAMS <configuration.html#ADDITIONAL_QUERY_PARAMS>`_ configuration key.
+* ``string``
+* ``number``
+* ``integer``
+* ``boolean``
+* ``array``
+* ``object``
 
+Acceptable formats
+------------------
 
-    ``string``: For string values.
+Common ``schema.format`` values include:
 
-    ``number``: For floating-point numbers.
+* ``date``
+* ``date-time``
+* ``password``
+* ``byte``
+* ``binary``
+* ``email``
+* ``uuid``
+* ``uri``
+* ``hostname``
+* ``ipv4``
+* ``ipv6``
+* ``int32``
+* ``int64``
+* ``float``
+* ``double``
 
-    ``integer``: For whole numbers.
-
-    ``boolean``: For true or false values.
-
-    ``array``: For arrays or lists of values.
-
-    ``object``: For JSON objects.
-
-Acceptable Formats
-^^^^^^^^^^^^^^^^^^^
-
-Below is a list of acceptable formats for the `schema` key in the `ADDITIONAL_QUERY_PARAMS <configuration.html#ADDITIONAL_QUERY_PARAMS>`_ configuration key.
-
-string formats
-    ``date``: Full-date according to RFC3339 (e.g., 2020-01-01).
-
-    ``date-time``: The date-time notation as defined by RFC 3339, section 5.6 (e.g., 2020-01-01T12:00:00Z).
-
-    ``password``: A hint to UIs to mask the input.
-
-    ``byte``: Base64-encoded characters, for binary data carried in JSON strings.
-
-    ``binary``: Binary data not encoded in a string, used for file uploads.
-
-    ``email``: String must be in email format.
-
-    ``uuid``: String must be a UUID.
-
-    ``uri``: String must be a URI.
-
-    ``hostname``: String must be a hostname.
-
-    ``ipv4``: String must be an IPv4.
-
-    ``ipv6``: String must be an IPv6.
-
-
-integer formats
-    ``int32``: Signed 32-bit integers.
-
-    ``int64``: Signed 64-bit integers (long).
-
-number formats
-    ``float``: Floating-point numbers.
-
-    ``double``: Double-precision floating-point numbers.
+For comprehensive configuration details see :doc:`configuration`.


### PR DESCRIPTION
## Summary
- streamline authentication guide with clearer examples
- overhaul callback documentation for concise lifecycle and configuration guidance

## Testing
- `ruff format flarchitect demo tests`
- `ruff check flarchitect demo tests` *(fails: Undefined name `AutoSchema`, line too long, etc.)*
- `pytest -q` *(KeyboardInterrupt: interrupted after partial run with 11 passed, 199490 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6899864cd1f4832284b5a00f03a07ee1