### PR TITLE
docs: link demos and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ if __name__ == "__main__":
     app.run(debug=True)
 ```
 
-For more examples check out the [demo](https://github.com/arched-dev/flarchitect/tree/master/demo) directory or read the [full documentation](docs/source/index.rst).
+For runnable examples check out the [demo](https://github.com/arched-dev/flarchitect/tree/master/demo) directory, browse the [unit tests](https://github.com/arched-dev/flarchitect/tree/master/tests) for real-world usage patterns or read the [full documentation](docs/source/index.rst).

--- a/demo/configuration/load.py
+++ b/demo/configuration/load.py
@@ -1,0 +1,59 @@
+"""Demo application showing configuration precedence in flarchitect.
+
+This example demonstrates how global and model-specific configuration
+values interact. Run the application and inspect the generated API to see
+rate limits applied at different levels.
+"""
+from __future__ import annotations
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from flarchitect.core.architect import Architect
+
+
+class BaseModel(DeclarativeBase):
+    """SQLAlchemy base model used by the demo."""
+
+    def get_session(*args) -> SQLAlchemy.Session:  # type: ignore[name-defined]
+        """Return the SQLAlchemy session for the current app context."""
+        return db.session  # type: ignore[name-defined]
+
+
+app = Flask(__name__)
+
+db = SQLAlchemy(model_class=BaseModel)
+
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+app.config["API_TITLE"] = "Config Demo API"
+app.config["API_VERSION"] = "1.0"
+app.config["API_BASE_MODEL"] = db.Model
+app.config["API_RATE_LIMIT"] = "100 per minute"
+app.config["API_GET_RATE_LIMIT"] = "50 per minute"
+
+
+class Author(db.Model):
+    """Simple model with overriding rate limit configuration."""
+
+    __tablename__ = "author"
+
+    class Meta:  # noqa: D106 - simple configuration container
+        tag_group = "People/Companies"
+        tag = "Author"
+        rate_limit = "10 per minute"
+        get_rate_limit = "5 per minute"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String)
+
+
+with app.app_context():
+    db.init_app(app)
+    db.create_all()
+    Architect(app)
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -82,3 +82,4 @@ For complete control supply your own callable:
 
 The ``demo/authentication/custom_auth.py`` module shows this approach in
 context.
+For end-to-end examples validated by tests, see `tests/test_authentication.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_authentication.py>`_.

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -138,6 +138,7 @@ Callback Examples
 --------------------------
 
 To demonstrate how to use callbacks, please see the demo folder of our `repo`_ or view the demo code `here <https://github.com/arched-dev/flarchitect/tree/master/demo/callbacks>`_.
+Additional examples are available in the unit tests - `test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
 
 
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -26,6 +26,9 @@ classes using `Meta` classes.
 `Flask`_ config values are the most straightforward way to configure the API. Offering a standardized approach to modifying
 the extension's behavior at a global or model level.
 
+For a runnable illustration of these concepts, see the demo - `configuration/load.py <https://github.com/arched-dev/flarchitect/blob/master/demo/configuration/load.py>`_.
+Unit tests covering configuration behaviour can be found in `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_ and the `model meta tests <https://github.com/arched-dev/flarchitect/tree/master/tests/test_model_meta>`_.
+
 
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,6 +98,8 @@ Let's get started!
 
 `View Demos <https://github.com/arched-dev/flarchitect/tree/master/demo>`__
 
+`Browse Unit Tests <https://github.com/arched-dev/flarchitect/tree/master/tests>`__
+
 
 .. image:: /_static/one_does_not.png
    :alt: One does not simply generate API's

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -20,3 +20,5 @@ Example::
         name = db.Column(db.String(80))
 
 That's all that's required to make the model available through the generated API.
+For extended model examples, explore the demo - `model_extension <https://github.com/arched-dev/flarchitect/tree/master/demo/model_extension>`_.
+Unit tests demonstrating model behaviour live in `tests/test_models.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_models.py>`_.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -218,3 +218,4 @@ Full Example
 To see a full example of this code, please see the ``demo`` directory in our `repo`_ or view the example - `quickstart demo <https://github.com/arched-dev/flarchitect/blob/master/demo/quickstart/load.py>`_
 
 For more indepth example flask application's start with the `basic factory application <https://github.com/arched-dev/flarchitect/tree/master/demo/basic_factory>`_
+For a minimal verified setup, check the unit tests - `test_basic.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_basic.py>`_


### PR DESCRIPTION
## Summary
- add configuration demo showcasing global and model overrides
- reference demo scripts and unit tests across documentation
- highlight tests in README and docs index

## Testing
- `ruff check --fix demo/configuration/load.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899869c094c8322b970ba5d0ce34c22