### PR TITLE
Expand callback documentation and tests

### DIFF
--- a/demo/callbacks/callbacks.py
+++ b/demo/callbacks/callbacks.py
@@ -1,4 +1,6 @@
-from demo.model_extension.model import create_app
+"""Entry point for running the callback demonstration app."""
+
+from demo.callbacks.model import create_app
 
 app = create_app()
 

--- a/demo/callbacks/model/callbacks.py
+++ b/demo/callbacks/model/callbacks.py
@@ -1,0 +1,49 @@
+"""Example callback functions for the callbacks demo application."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def setup_callback(*, model, **kwargs) -> dict[str, Any]:
+    """Example setup callback used in the demo.
+
+    Args:
+        model: The model class being accessed.
+        **kwargs: Additional keyword arguments passed from the framework.
+
+    Returns:
+        Dict[str, Any]: Potentially modified keyword arguments.
+    """
+    return kwargs
+
+
+def return_callback(*, model, output, **kwargs) -> dict[str, Any]:
+    """Example return callback used in the demo.
+
+    Args:
+        model: The model class being accessed.
+        output: The value returned from the database operation.
+        **kwargs: Additional keyword arguments.
+
+    Returns:
+        Dict[str, Any]: A dictionary containing the ``output`` key.
+    """
+    return {"output": output}
+
+
+def final_callback(data: dict[str, Any]) -> dict[str, Any]:
+    """Attach a marker before the response is sent."""
+    data["finalized"] = True
+    return data
+
+
+def error_callback(error: str, status_code: int, value: Any) -> None:
+    """Handle errors raised during a request."""
+    _ = (error, status_code, value)  # Placeholder for real logging.
+
+
+def dump_callback(data: dict[str, Any], **kwargs) -> dict[str, Any]:
+    """Modify serialised data prior to returning it to the client."""
+    data["demo"] = True
+    return data

--- a/demo/callbacks/model/config.py
+++ b/demo/callbacks/model/config.py
@@ -1,3 +1,10 @@
+from demo.callbacks.model.callbacks import (
+    dump_callback,
+    error_callback,
+    final_callback,
+    return_callback,
+    setup_callback,
+)
 from demo.callbacks.model.extensions import db
 
 
@@ -11,3 +18,8 @@ class Config:
     API_DOCS_FONT = "montserrat"
     API_RATE_LIMIT = "5 per minute"
     SECRET_KEY = "8Kobns1_vnmg3rxnr0RZpkF4D1s"
+    API_SETUP_CALLBACK = setup_callback
+    API_RETURN_CALLBACK = return_callback
+    API_FINAL_CALLBACK = final_callback
+    API_ERROR_CALLBACK = error_callback
+    API_DUMP_CALLBACK = dump_callback

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -634,6 +634,19 @@ API Callbacks
 
 
     *
+        - .. data:: GLOBAL_SETUP_CALLBACK
+
+          :bdg:`default:` ``None``
+
+          :bdg:`type` ``callable``
+
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global Method`
+
+        - Executes before any model specific processing. Useful for cross-cutting
+          concerns such as authentication or logging.
+
+            View an example function & its signature `here <callbacks.html#setup-global-setup-and-filter>`_.
+    *
         - .. data:: SETUP_CALLBACK
 
           :bdg:`default:` ``None``
@@ -642,13 +655,12 @@ API Callbacks
 
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
-        - When assigned, the API will call the function prior to the model being queried.
-          This is useful for adding custom logic to the API, such as adding additional query parameters/modifying the
-          query or logging request to the database.
+        - Called prior to the model being queried. Useful for adding additional
+          query parameters or performing validation.
 
-            View an example function & its signature `here <callbacks.html#setup-function-signature>`_.
+            View an example function & its signature `here <callbacks.html#setup-global-setup-and-filter>`_.
     *
-        - .. data:: POST_DUMP_CALLBACK
+        - .. data:: FILTER_CALLBACK
 
           :bdg:`default:` ``None``
 
@@ -656,11 +668,59 @@ API Callbacks
 
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
-        - When assigned, the API will call the function after the model has been dumped to a dictionary by Marshmallow.
-          Its possible to add extra validation here or modify the response data.
+        - Allows modification of the SQLAlchemy query before filters and
+          pagination are applied.
 
-          View an example function & its signature `here <callbacks.html#post-dump-function-signature>`_.
+            View an example function & its signature `here <callbacks.html#setup-global-setup-and-filter>`_.
+    *
+        - .. data:: ADD_CALLBACK
 
+          :bdg:`default:` ``None``
+
+          :bdg:`type` ``callable``
+
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
+        - Invoked before a new object is added to the session.
+
+            View an example function & its signature `here <callbacks.html#add-update-and-remove>`_.
+    *
+        - .. data:: UPDATE_CALLBACK
+
+          :bdg:`default:` ``None``
+
+          :bdg:`type` ``callable``
+
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
+        - Runs prior to committing updates to an existing object.
+
+            View an example function & its signature `here <callbacks.html#add-update-and-remove>`_.
+    *
+        - .. data:: REMOVE_CALLBACK
+
+          :bdg:`default:` ``None``
+
+          :bdg:`type` ``callable``
+
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
+        - Called before deleting an object from the database.
+
+            View an example function & its signature `here <callbacks.html#add-update-and-remove>`_.
+    *
+        - .. data:: DUMP_CALLBACK
+
+          :bdg:`default:` ``None``
+
+          :bdg:`type` ``callable``
+
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
+        - Runs after the model has been serialised to a dictionary by Marshmallow,
+          allowing last minute modifications to the payload.
+
+          View an example function & its signature `here <callbacks.html#dump>`_.
     *
         - .. data:: RETURN_CALLBACK
 
@@ -670,12 +730,23 @@ API Callbacks
 
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
-        - When assigned, the API will call the function post database call and pre returning
-          the data to the client. This is useful for adding custom logic to the API, such as modifying the response data
-          or logging the response to the database.
+        - Called after the database operation but before the response is
+          returned. Useful for adjusting the response or adding headers.
 
-            View an example function & its signature `here <callbacks.html#return-function-signature>`_.
+            View an example function & its signature `here <callbacks.html#return>`_.
+    *
+        - .. data:: FINAL_CALLBACK
 
+          :bdg:`default:` ``None``
+
+          :bdg:`type` ``callable``
+
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global/Model Method`
+
+        - Invoked on the final response dictionary immediately before it is
+          serialised and returned to the client.
+
+            View an example function & its signature `here <callbacks.html#final>`_.
     *
         - .. data:: ERROR_CALLBACK
 
@@ -685,11 +756,9 @@ API Callbacks
 
           :bdg-secondary:`Optional` :bdg-dark-line:`Global Method`
 
-        - When assigned, the API will call the function when an error occurs. This is useful
-          for adding custom logic to the API, such as logging the error to the database, sending an emails etc.
+        - Triggered when an error occurs, allowing logging or notifications.
 
-            View an example function & its signature `here <callbacks.html#error-function-signature>`_.
-
+            View an example function & its signature `here <callbacks.html#error>`_.
     *
         - .. data:: ADDITIONAL_QUERY_PARAMS
 


### PR DESCRIPTION
## Summary
- document all callback types and their configuration
- add demo callbacks and config examples
- test final and error callbacks

## Testing
- `ruff check --fix tests/test_flask_config.py demo/callbacks/model/callbacks.py demo/callbacks/model/config.py demo/callbacks/callbacks.py`
- `ruff format tests/test_flask_config.py demo/callbacks/model/callbacks.py demo/callbacks/model/config.py demo/callbacks/callbacks.py`
- `pytest tests/test_flask_config.py -k test_callbacks -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_68998b7863e08322adaedcd4b1ee4951