### PR TITLE
Add type hints and detailed docstrings

### DIFF
--- a/flarchitect/authentication/user.py
+++ b/flarchitect/authentication/user.py
@@ -1,19 +1,40 @@
 # auth.py
+"""Utilities for managing user context within requests.
+
+These helpers wrap a :class:`contextvars.ContextVar` to provide a global-like
+interface for accessing the current user while remaining thread-safe.
+"""
+
 from contextvars import ContextVar
+from typing import Any
 
 from werkzeug.local import LocalProxy
 
 # Create a ContextVar to store the current user
-_current_user_ctx_var = ContextVar("current_user", default=None)
+_current_user_ctx_var: ContextVar[Any] = ContextVar("current_user", default=None)
 
 
-def set_current_user(user):
-    """Set the current user in the context."""
+def set_current_user(user: Any) -> None:
+    """Store the given user in the context.
+
+    Args:
+        user (Any): The user object to place into context. ``None`` clears the
+            current user.
+
+    Returns:
+        None: This function does not return a value.
+    """
+
     _current_user_ctx_var.set(user)
 
 
-def get_current_user():
-    """Get the current user from the context."""
+def get_current_user() -> Any | None:
+    """Retrieve the user stored in the context.
+
+    Returns:
+        Any | None: The current user if one has been set, otherwise ``None``.
+    """
+
     return _current_user_ctx_var.get()
 
 


### PR DESCRIPTION
## Summary
- document authentication helpers with module-level context and typing
- add JWT auth decorator documentation and teardown cleanup docs
- expand JWT utility docstrings and type hints with error handling

## Testing
- `ruff check flarchitect/authentication/user.py flarchitect/core/architect.py flarchitect/authentication/jwt.py --fix`
- `ruff format flarchitect/authentication/user.py flarchitect/core/architect.py flarchitect/authentication/jwt.py`
- `pytest` *(fails: tests/test_flask_config.py::test_callbacks - AssertionError)*

------
https://chatgpt.com/codex/tasks/task_e_6899a81c540483228fa249ba1d5c9e38