### PR TITLE
feat: support nested relationship writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQ
 - **Built-in authentication** – ship with JWT, basic and API key strategies out of the box, or plug in your own authentication.
 - **Rate limiting & structured responses** – configurable throttling and responses with a consistent schema.
 - **Highly configurable** – tweak behaviour globally via Flask config or per model with `Meta` attributes.
+- **Nested writes** – send related objects in POST/PUT payloads and let `AutoSchema` deserialize them automatically.
 
 ## Installation
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -20,3 +20,27 @@ Example::
         name = db.Column(db.String(80))
 
 That's all that's required to make the model available through the generated API.
+
+Nested model creation
+---------------------
+
+`AutoSchema` can also deserialize nested relationship data during POST or PUT
+requests. Include related objects under the relationship name in your payload::
+
+    {
+        "title": "My Book",
+        "isbn": "12345",
+        "publication_date": "2024-01-01",
+        "author_id": 1,
+        "author": {
+            "first_name": "John",
+            "last_name": "Doe",
+            "biography": "Bio",
+            "date_of_birth": "1980-01-01",
+            "nationality": "US"
+        }
+    }
+
+The nested ``author`` object is deserialized into an ``Author`` instance while
+responses continue to use the configured serialization type (URL, JSON, or
+dynamic).

--- a/tests/test_nested_relationship.py
+++ b/tests/test_nested_relationship.py
@@ -1,0 +1,37 @@
+import pytest
+from marshmallow import fields
+
+from demo.basic_factory.basic_factory import create_app
+from demo.basic_factory.basic_factory.models import Book
+from flarchitect.schemas.utils import get_input_output_from_model_or_make
+
+
+@pytest.fixture
+def app():
+    app = create_app({"API_TITLE": "Automated test", "API_VERSION": "0.2.0"})
+    with app.app_context():
+        yield app
+
+
+def test_auto_schema_loads_nested_relationship(app):
+    """Ensure nested relationship data can be deserialized."""
+    with app.app_context():
+        _, schema = get_input_output_from_model_or_make(Book)
+        assert isinstance(schema.dump_fields["author"], fields.Function)
+        assert isinstance(schema.load_fields["author"], fields.Nested)
+        data = {
+            "title": "My Book",
+            "isbn": "12345",
+            "publication_date": "2024-01-01",
+            "author_id": 1,
+            "publisher_id": 1,
+            "author": {
+                "first_name": "John",
+                "last_name": "Doe",
+                "biography": "bio",
+                "date_of_birth": "1980-01-01",
+                "nationality": "US",
+            },
+        }
+        result = schema.load(data)
+        assert result["author"]["first_name"] == "John"


### PR DESCRIPTION
## Summary
- allow AutoSchema to deserialize nested relationship data while keeping URL-based serialization
- document nested model creation and expose nested write capability in README
- cover relationship loading with a dedicated test

## Testing
- `ruff check --fix flarchitect/schemas/bases.py tests/test_nested_relationship.py` *(fails: bare except, line length, etc.)*
- `ruff format flarchitect/schemas/bases.py tests/test_nested_relationship.py`
- `pytest tests/test_nested_relationship.py`


------
https://chatgpt.com/codex/tasks/task_e_6899c945368483229ae7a78251943cba