### PR TITLE
Add CI test workflow and README updates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+          pip install pytest
+      - name: Lint with ruff
+        run: ruff --output-format=github --no-cache .
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 /flarchitect.egg-info/
 /dist/
 /build/
-/.github/
 /flarchitect.egg-info/
 /htmlcov/
 /.coverage
@@ -15,7 +14,6 @@
 /rough_readne.MD
 .env
 /.env
-/.github/
 /.venv/
 /dist/
 /flarchitect.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # flarchitect
 
+[![Tests](https://github.com/arched-dev/flarchitect/actions/workflows/tests.yml/badge.svg)](https://github.com/arched-dev/flarchitect/actions/workflows/tests.yml)
+
 flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQLAlchemy models into a production-ready REST API with almost no boilerplate. It automatically builds CRUD endpoints, generates interactive Redoc documentation and keeps responses consistent so you can focus on your application logic.
 
 ## Features
@@ -36,9 +38,28 @@ if __name__ == "__main__":
     app.run(debug=True)
 ```
 
+## Running Tests
+
+To run the test suite locally:
+
+```bash
+pytest
+```
+
 ## Documentation & help
 
 - Browse the [full documentation](docs/source/index.rst) for tutorials and API reference.
 - Explore runnable examples in the [demo](https://github.com/arched-dev/flarchitect/tree/master/demo) directory.
 - Questions? Join the [GitHub discussions](https://github.com/arched-dev/flarchitect/discussions) or open an [issue](https://github.com/arched-dev/flarchitect/issues).
+
+## Contributing
+
+Contributions are welcome! For major changes, please open an issue first to discuss what you would like to change.
+
+Before submitting a pull request, ensure that linters and tests pass locally:
+
+```bash
+ruff --fix .
+pytest
+```
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Ruff and pytest on pushes and pull requests
- expose test status badge and contributing guidance in README
- allow tracking of workflow files in version control

## Testing
- `ruff check flarchitect` *(fails: 151 errors)*
- `pytest` *(fails: tests/test_flask_config.py::test_callbacks)*

------
https://chatgpt.com/codex/tasks/task_e_689c29d1c13c832290d61796bbc4d60a