### PR TITLE
feat: enable nested write operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQ
 - **Built-in authentication** – ship with JWT, basic and API key strategies out of the box, or plug in your own authentication.
 - **Rate limiting & structured responses** – configurable throttling and responses with a consistent schema.
 - **Highly configurable** – tweak behaviour globally via Flask config or per model with `Meta` attributes.
-- **Nested writes** – send related objects in POST/PUT payloads and let `AutoSchema` deserialize them automatically.
+- **Nested writes** – opt-in support for sending related objects in POST/PUT payloads. Enable with `API_ALLOW_NESTED_WRITES = True` and let `AutoSchema` deserialize them automatically.
 
 ## Installation
 
@@ -29,6 +29,7 @@ app = Flask(__name__)
 app.config["API_TITLE"] = "My API"
 app.config["API_VERSION"] = "1.0"
 app.config["API_BASE_MODEL"] = BaseModel
+app.config["API_ALLOW_NESTED_WRITES"] = True
 
 architect = Architect(app)
 

--- a/demo/basic_factory/basic_factory/config.py
+++ b/demo/basic_factory/basic_factory/config.py
@@ -9,3 +9,4 @@ class Config:
     API_VERSION = "0.1.0"
     API_VERBOSITY_LEVEL = 4
     SECRET_KEY = "8Kobns1_vnmg3rxnr0RZpkF4D1s"
+    API_ALLOW_NESTED_WRITES = False

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -240,3 +240,9 @@ Documentation Configuration Values
           :bdg:`type` ``int``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
         - Console output verbosity (0–4).
+
+    * - .. data:: ALLOW_NESTED_WRITES
+          :bdg:`default:` ``False``
+          :bdg:`type` ``bool``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+        - Enable POST/PATCH requests to include nested related objects.

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -24,8 +24,11 @@ That's all that's required to make the model available through the generated API
 Nested model creation
 ---------------------
 
-`AutoSchema` can also deserialize nested relationship data during POST or PUT
-requests. Include related objects under the relationship name in your payload::
+Nested writes are disabled by default. Enable them globally with
+``API_ALLOW_NESTED_WRITES = True`` or per model via ``Meta.allow_nested_writes``.
+Once enabled, ``AutoSchema`` can deserialize nested relationship data during
+POST or PUT requests. Include related objects under the relationship name in
+your payload::
 
     {
         "title": "My Book",

--- a/tests/test_nested_relationship.py
+++ b/tests/test_nested_relationship.py
@@ -8,7 +8,13 @@ from flarchitect.schemas.utils import get_input_output_from_model_or_make
 
 @pytest.fixture
 def app():
-    app = create_app({"API_TITLE": "Automated test", "API_VERSION": "0.2.0"})
+    app = create_app(
+        {
+            "API_TITLE": "Automated test",
+            "API_VERSION": "0.2.0",
+            "API_ALLOW_NESTED_WRITES": True,
+        }
+    )
     with app.app_context():
         yield app
 

--- a/tests/test_nested_writes.py
+++ b/tests/test_nested_writes.py
@@ -1,0 +1,118 @@
+import pytest
+
+from demo.basic_factory.basic_factory import create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app(
+        {
+            "API_TITLE": "Automated test",
+            "API_VERSION": "0.2.0",
+            "API_ALLOW_NESTED_WRITES": True,
+        }
+    )
+    with app.app_context():
+        yield app.test_client()
+
+
+def test_post_author_with_two_books(client):
+    data = {
+        "first_name": "Nested",
+        "last_name": "Author",
+        "biography": "Bio",
+        "date_of_birth": "1990-01-01",
+        "nationality": "US",
+        "books": [
+            {
+                "title": "Book 1",
+                "isbn": "11111",
+                "publication_date": "2024-01-01",
+                "publisher_id": 1,
+                "author_id": 0,
+            },
+            {
+                "title": "Book 2",
+                "isbn": "22222",
+                "publication_date": "2024-01-02",
+                "publisher_id": 1,
+                "author_id": 0,
+            },
+        ],
+    }
+    resp = client.post("/api/authors", json=data)
+    assert resp.status_code == 200
+    author_id = resp.json["value"]["id"]
+    books_resp = client.get(f"/api/authors/{author_id}/books")
+    assert books_resp.status_code == 200
+    assert len(books_resp.json["value"]) == 2
+
+
+def test_post_publisher_with_two_authors(client):
+    data = {
+        "name": "Pub Nested",
+        "website": "https://pubnested.com",
+        "foundation_year": 2020,
+        "books": [
+            {
+                "title": "PB1",
+                "isbn": "33333",
+                "publication_date": "2024-01-01",
+                "author_id": 0,
+                "publisher_id": 0,
+                "author": {
+                    "first_name": "A1",
+                    "last_name": "B1",
+                    "biography": "Bio",
+                    "date_of_birth": "1980-01-01",
+                    "nationality": "US",
+                },
+            },
+            {
+                "title": "PB2",
+                "isbn": "44444",
+                "publication_date": "2024-01-02",
+                "author_id": 0,
+                "publisher_id": 0,
+                "author": {
+                    "first_name": "A2",
+                    "last_name": "B2",
+                    "biography": "Bio",
+                    "date_of_birth": "1981-01-01",
+                    "nationality": "US",
+                },
+            },
+        ],
+    }
+    resp = client.post("/api/publishers", json=data)
+    assert resp.status_code == 200
+    pub_id = resp.json["value"]["id"]
+    books_resp = client.get(f"/api/publishers/{pub_id}/books")
+    assert books_resp.status_code == 200
+    assert len(books_resp.json["value"]) == 2
+    author_ids = {book["author_id"] for book in books_resp.json["value"]}
+    assert len(author_ids) == 2
+
+
+def test_post_book_with_author_and_publisher(client):
+    data = {
+        "title": "Standalone",
+        "isbn": "99999",
+        "publication_date": "2024-01-01",
+        "author_id": 0,
+        "publisher_id": 0,
+        "author": {
+            "first_name": "Nested",
+            "last_name": "Writer",
+            "biography": "Bio",
+            "date_of_birth": "1980-01-01",
+            "nationality": "US",
+        },
+        "publisher": {
+            "name": "Nested Pub",
+            "website": "https://nestedpub.com",
+            "foundation_year": 2021,
+        },
+    }
+    resp = client.post("/api/books", json=data)
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add optional API_ALLOW_NESTED_WRITES to accept nested objects on POST/PATCH
- document nested write behaviour and config flag
- add tests for posting nested authors, publishers and books

## Testing
- `ruff check --fix flarchitect/schemas/bases.py flarchitect/database/operations.py demo/basic_factory/basic_factory/config.py docs/source/models.rst docs/source/configuration.rst README.md tests/test_nested_relationship.py tests/test_nested_writes.py`
- `pytest tests/test_nested_writes.py tests/test_nested_relationship.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2bee9bbc83229186830e1bd30395