### PR TITLE
docs: expand openapi and faq

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ if __name__ == "__main__":
     app.run(debug=True)
 ```
 
+## OpenAPI specification
+
+An OpenAPI 3 schema is generated automatically and powers the Redoc UI. You
+can serve the raw specification to integrate with tooling such as Postman:
+
+```python
+from flask import Flask, Response, jsonify
+from flarchitect.core.architect import Architect
+
+app = Flask(__name__)
+architect = Architect(app)
+
+@app.get("/openapi.json")
+def openapi() -> Response:
+    return jsonify(architect.api_spec.to_dict())
+```
+
+See the [OpenAPI docs](docs/source/openapi.rst) for exporting or customising
+the document.
+
 ## Running Tests
 
 To run the test suite locally:

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -82,3 +82,29 @@ FAQ
         `API_SOFT_DELETE_ATTRIBUTE <configuration.html#SOFT_DELETE_ATTRIBUTE>`_
 
         `API_SOFT_DELETE_VALUES <configuration.html#SOFT_DELETE_VALUES>`_
+
+.. dropdown:: Can I generate an OpenAPI specification document?
+
+    Yes. When ``API_CREATE_DOCS`` is enabled the schema is automatically
+    generated at start-up and served at ``/openapi.json``. See
+    :doc:`openapi` for examples on exporting or customising the document.
+
+.. dropdown:: How do I update documentation after adding new models?
+
+    Restart your application. The specification is rebuilt on boot and will
+    include any newly registered models or routes.
+
+Troubleshooting
+---------------
+
+.. dropdown:: The documentation endpoint returns 404
+
+    Ensure ``API_CREATE_DOCS`` is set to ``True`` and that the
+    :class:`flarchitect.core.architect.Architect` has been initialised. If
+    you mount the app under a prefix, check ``documentation_url_prefix``.
+
+.. dropdown:: A route is missing from the spec
+
+    Confirm the model has a ``Meta`` class and the endpoint isn't blocked by
+    ``API_BLOCK_METHODS``. Rebuilding the application will refresh the
+    specification.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ flarchitect
    authentication
    callbacks
    configuration
+   openapi
    faq
    genindex
 

--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -1,0 +1,58 @@
+OpenAPI Specification
+=========================================
+
+flarchitect automatically generates an OpenAPI 3.0.2 document for every
+registered model. The specification powers the interactive Redoc page and
+can also be reused with external tools like Postman or Swagger UI.
+
+Automatic generation
+--------------------
+
+When ``API_CREATE_DOCS`` is enabled (it is ``True`` by default) the
+specification is built on start-up by inspecting the routes and schemas
+registered with :class:`flarchitect.core.architect.Architect`.  Any models
+added later are included the next time the application boots.
+
+Accessing the spec
+------------------
+
+The generated schema is served at ``/openapi.json``.  You can expose it
+manually if you prefer:
+
+.. code-block:: python
+
+    from flask import Flask, Response, jsonify
+    from flarchitect.core.architect import Architect
+
+    app = Flask(__name__)
+    architect = Architect(app)
+
+    @app.get("/openapi.json")
+    def openapi() -> Response:
+        return jsonify(architect.api_spec.to_dict())
+
+Exporting to a file
+-------------------
+
+To generate a static JSON document for deployment or tooling:
+
+.. code-block:: python
+
+    import json
+
+    with open("openapi.json", "w") as fh:
+        json.dump(architect.api_spec.to_dict(), fh, indent=2)
+
+Customising the document
+------------------------
+
+A number of configuration keys let you tailor the output:
+
+* ``API_TITLE`` – title displayed in the document
+* ``API_VERSION`` – semantic version string
+* ``API_DESCRIPTION`` – path to a README-style file rendered into the
+  ``info`` section
+* ``API_LOGO_URL`` and ``API_LOGO_BACKGROUND`` – brand the Redoc page
+
+See :doc:`configuration` for the full list of options.
+


### PR DESCRIPTION
## Summary
- add OpenAPI specification documentation
- link new OpenAPI page in docs index
- expand FAQ with troubleshooting tips

## Testing
- `ruff check --fix flarchitect`
- `pytest` *(fails: ImportError: cannot import name 'get_model_columns' from partially initialized module 'flarchitect.database.operations')*


------
https://chatgpt.com/codex/tasks/task_e_689c34b5c65c83228da136ce6d1ba9a7