### PR TITLE
refactor: isolate model inspection helpers

### DIFF
--- a/flarchitect/database/inspections.py
+++ b/flarchitect/database/inspections.py
@@ -1,0 +1,48 @@
+"""Utility functions for inspecting SQLAlchemy models.
+
+This module provides helper functions to extract information from SQLAlchemy
+models without introducing heavy dependencies. The functions are kept in a
+stand-alone module to avoid circular imports between the database operations
+module and specification utilities.
+"""
+
+from __future__ import annotations
+
+import random
+
+from sqlalchemy import inspect
+from sqlalchemy.orm import DeclarativeBase
+
+
+def get_model_relationships(
+    model: DeclarativeBase, randomise: bool = True
+) -> list[type[DeclarativeBase]]:
+    """Extract relationship models from a SQLAlchemy model.
+
+    Args:
+        model: The SQLAlchemy model to inspect.
+        randomise: If ``True`` the order of the relationships is randomised.
+
+    Returns:
+        List of related model classes.
+    """
+    relationships = [rel.mapper.class_ for rel in inspect(model).relationships]
+    if randomise:
+        random.shuffle(relationships)
+    return relationships
+
+
+def get_model_columns(model: DeclarativeBase, randomise: bool = True) -> list[str]:
+    """Return a list of column names for a SQLAlchemy model.
+
+    Args:
+        model: The SQLAlchemy model to inspect.
+        randomise: If ``True`` the order of the column names is randomised.
+
+    Returns:
+        List of column names defined on ``model``.
+    """
+    columns = [column.name for column in inspect(model).mapper.columns]
+    if randomise:
+        random.shuffle(columns)
+    return columns

--- a/flarchitect/database/operations.py
+++ b/flarchitect/database/operations.py
@@ -1,4 +1,3 @@
-import random
 from collections.abc import Callable
 from typing import Any
 
@@ -9,6 +8,10 @@ from sqlalchemy.orm import DeclarativeBase, Query, Session, object_session
 from sqlalchemy.orm.exc import UnmappedInstanceError
 
 from flarchitect.core.utils import get_primary_key_info
+from flarchitect.database.inspections import (
+    get_model_columns,
+    get_model_relationships,
+)
 from flarchitect.database.utils import (
     generate_conditions_from_args,
     get_all_columns_and_hybrids,
@@ -22,39 +25,13 @@ from flarchitect.exceptions import CustomHTTPException
 from flarchitect.utils.config_helpers import get_config_or_model_meta
 from flarchitect.utils.decorators import add_dict_to_query, add_page_totals_and_urls
 
-
-def get_model_relationships(model: DeclarativeBase, randomise: bool = True) -> list[type[DeclarativeBase]]:
-    """
-    Extracts relationships from a SQLAlchemy model.
-
-    Args:
-        model (DeclarativeBase): The SQLAlchemy model.
-        randomise (bool, optional): Whether to randomise the order of relationships.
-
-    Returns:
-        List[Type[DeclarativeBase]]: A list of related models.
-    """
-    relationships = [relationship.mapper.class_ for relationship in inspect(model).relationships]
-    if randomise:
-        random.shuffle(relationships)
-    return relationships
-
-
-def get_model_columns(model: DeclarativeBase, randomise: bool = True) -> list[str]:
-    """
-    Extracts column names from a SQLAlchemy model.
-
-    Args:
-        model (DeclarativeBase): The SQLAlchemy model.
-        randomise (bool, optional): Whether to randomize the order of columns.
-
-    Returns:
-        List[str]: A list of column names.
-    """
-    columns = [x.name for x in list(inspect(model).mapper.columns)]
-    if randomise:
-        random.shuffle(columns)
-    return columns
+__all__ = [
+    "paginate_query",
+    "apply_sorting_to_query",
+    "CrudService",
+    "get_model_columns",
+    "get_model_relationships",
+]
 
 
 def paginate_query(sql_query: Query, page: int = 0, items_per_page: int | None = None) -> Query:

--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -16,7 +16,10 @@ from werkzeug.routing import IntegerConverter, UnicodeConverter
 
 import flarchitect.utils
 import flarchitect.utils.decorators
-from flarchitect.database.operations import get_model_columns, get_model_relationships
+from flarchitect.database.inspections import (
+    get_model_columns,
+    get_model_relationships,
+)
 from flarchitect.database.utils import AGGREGATE_FUNCS
 from flarchitect.logging import logger
 from flarchitect.utils.config_helpers import get_config_or_model_meta

--- a/tests/test_inspections.py
+++ b/tests/test_inspections.py
@@ -1,0 +1,38 @@
+"""Tests for model inspection helper functions."""
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from flarchitect.database.inspections import (
+    get_model_columns,
+    get_model_relationships,
+)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Parent(Base):
+    __tablename__ = "parent"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    children: Mapped[list["Child"]] = relationship(back_populates="parent")
+
+
+class Child(Base):
+    __tablename__ = "child"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    parent_id: Mapped[int] = mapped_column(ForeignKey("parent.id"))
+    parent: Mapped[Parent] = relationship(back_populates="children")
+
+
+def test_get_model_columns() -> None:
+    """Ensure column names are correctly extracted."""
+    assert get_model_columns(Parent, randomise=False) == ["id"]
+
+
+def test_get_model_relationships() -> None:
+    """Ensure related models are correctly extracted."""
+    assert get_model_relationships(Parent, randomise=False) == [Child]


### PR DESCRIPTION
## Summary
- move SQLAlchemy model inspection helpers to a dedicated module to avoid circular imports
- re-export inspection helpers from database operations
- cover new helpers with unit tests

## Testing
- `pytest tests/test_inspections.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'marshmallow_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689c3450a4508322bc009f33c135e802