### PR TITLE
Expose Architect from package root

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pip install flarchitect
 
 ```python
 from flask import Flask
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 from models import Author, BaseModel  # your SQLAlchemy models
 
 app = Flask(__name__)
@@ -47,7 +47,7 @@ can serve the raw specification to integrate with tooling such as Postman:
 
 ```python
 from flask import Flask, Response, jsonify
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 app = Flask(__name__)
 architect = Architect(app)

--- a/demo/authentication/app_base.py
+++ b/demo/authentication/app_base.py
@@ -8,7 +8,7 @@ from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 
 class BaseModel(DeclarativeBase):

--- a/demo/authentication/model/extensions.py
+++ b/demo/authentication/model/extensions.py
@@ -4,7 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 
 class BaseModel(DeclarativeBase):

--- a/demo/basic_factory/basic_factory/extensions.py
+++ b/demo/basic_factory/basic_factory/extensions.py
@@ -4,7 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 
 class BaseModel(DeclarativeBase):

--- a/demo/callbacks/model/extensions.py
+++ b/demo/callbacks/model/extensions.py
@@ -4,7 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 
 class BaseModel(DeclarativeBase):

--- a/demo/model_extension/model/extensions.py
+++ b/demo/model_extension/model/extensions.py
@@ -4,7 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 
 class BaseModel(DeclarativeBase):

--- a/demo/quickstart/load.py
+++ b/demo/quickstart/load.py
@@ -5,7 +5,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import Date, Integer, String, Text
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 
 # Create a base model that all models will inherit from. This is a requirement for the auto api creator to work.

--- a/demo/soft_delete/soft_delete/extensions.py
+++ b/demo/soft_delete/soft_delete/extensions.py
@@ -4,7 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import Boolean, DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 
 class BaseModel(DeclarativeBase):

--- a/docs/build/html/_sources/quickstart.rst.txt
+++ b/docs/build/html/_sources/quickstart.rst.txt
@@ -139,7 +139,7 @@ The only other requirement's are a few configuration values that need to be pass
 
               from flask import Flask
               from flask_sqlalchemy import SQLAlchemy
-              from flarchitect.core.architect import Architect
+              from flarchitect import Architect
 
               app = Flask(__name__)
 
@@ -166,7 +166,7 @@ The only other requirement's are a few configuration values that need to be pass
         .. code:: python
 
               from flask import Flask
-              from flarchitect.core.architect import Architect
+              from flarchitect import Architect
 
               app = Flask(__name__)
 

--- a/docs/build/html/quickstart.html
+++ b/docs/build/html/quickstart.html
@@ -399,7 +399,7 @@ but pass in <code class="docutils literal notranslate"><span class="pre">db.Mode
 to your models.</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">flask</span> <span class="kn">import</span> <span class="n">Flask</span>
 <span class="kn">from</span> <span class="nn">flask_sqlalchemy</span> <span class="kn">import</span> <span class="n">SQLAlchemy</span>
-<span class="kn">from</span> <span class="nn">flarchitect.core.architect</span> <span class="kn">import</span> <span class="n">Architect</span>
+<span class="kn">from</span> <span class="nn">flarchitect</span> <span class="kn">import</span> <span class="n">Architect</span>
 
 <span class="n">app</span> <span class="o">=</span> <span class="n">Flask</span><span class="p">(</span><span class="vm">__name__</span><span class="p">)</span>
 
@@ -426,7 +426,7 @@ to your models.</p>
 vanilla sqlalchemy</label><div class="sd-tab-content docutils">
 <p>When using <a class="reference external" href="https://docs.sqlalchemy.org/en/latest/">SQLAlchemy</a> you will have to set the <cite>API_BASE_MODEL</cite> in the <a class="reference external" href="https://flask.palletsprojects.com/en/latest/">Flask</a> config.</p>
 <div class="highlight-python notranslate"><div class="highlight"><pre><span></span><span class="kn">from</span> <span class="nn">flask</span> <span class="kn">import</span> <span class="n">Flask</span>
-<span class="kn">from</span> <span class="nn">flarchitect.core.architect</span> <span class="kn">import</span> <span class="n">Architect</span>
+<span class="kn">from</span> <span class="nn">flarchitect</span> <span class="kn">import</span> <span class="n">Architect</span>
 
 <span class="n">app</span> <span class="o">=</span> <span class="n">Flask</span><span class="p">(</span><span class="vm">__name__</span><span class="p">)</span>
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -100,7 +100,7 @@ Troubleshooting
 .. dropdown:: The documentation endpoint returns 404
 
     Ensure ``API_CREATE_DOCS`` is set to ``True`` and that the
-    :class:`flarchitect.core.architect.Architect` has been initialised. If
+    :class:`flarchitect.Architect` has been initialised. If
     you mount the app under a prefix, check ``documentation_url_prefix``.
 
 .. dropdown:: A route is missing from the spec

--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -10,7 +10,7 @@ Automatic generation
 
 When ``API_CREATE_DOCS`` is enabled (it is ``True`` by default) the
 specification is built on start-up by inspecting the routes and schemas
-registered with :class:`flarchitect.core.architect.Architect`.  Any models
+registered with :class:`flarchitect.Architect`.  Any models
 added later are included the next time the application boots.
 
 Accessing the spec
@@ -22,7 +22,7 @@ manually if you prefer:
 .. code-block:: python
 
     from flask import Flask, Response, jsonify
-    from flarchitect.core.architect import Architect
+    from flarchitect import Architect
 
     app = Flask(__name__)
     architect = Architect(app)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -139,7 +139,7 @@ The only other requirement's are a few configuration values that need to be pass
 
               from flask import Flask
               from flask_sqlalchemy import SQLAlchemy
-              from flarchitect.core.architect import Architect
+              from flarchitect import Architect
 
               app = Flask(__name__)
 
@@ -166,7 +166,7 @@ The only other requirement's are a few configuration values that need to be pass
         .. code:: python
 
               from flask import Flask
-              from flarchitect.core.architect import Architect
+              from flarchitect import Architect
 
               app = Flask(__name__)
 

--- a/flarchitect/__init__.py
+++ b/flarchitect/__init__.py
@@ -1,0 +1,12 @@
+"""Convenient exports for the :mod:`flarchitect` package.
+
+This module exposes the primary public interface so users can simply do::
+
+    from flarchitect import Architect
+
+rather than importing from the internal ``core`` package.
+"""
+
+from .core.architect import Architect
+
+__all__ = ["Architect"]

--- a/flarchitect/core/routes.py
+++ b/flarchitect/core/routes.py
@@ -41,7 +41,7 @@ from flarchitect.utils.config_helpers import get_config_or_model_meta
 from flarchitect.utils.general import AttributeInitializerMixin
 
 if TYPE_CHECKING:
-    from flarchitect.core.architect import Architect
+    from flarchitect import Architect
 
 
 def create_params_from_rule(model: DeclarativeBase, rule, schema: Schema) -> list[dict[str, Any]]:

--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -36,7 +36,7 @@ from flarchitect.utils.general import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover - imported only for type hints
-    from flarchitect.core.architect import Architect
+    from flarchitect import Architect
 
 
 class CustomSpec(APISpec, AttributeInitializerMixin):

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -20,7 +20,7 @@ from flarchitect.authentication.user import (
     get_current_user,
     set_current_user,
 )
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 from flarchitect.exceptions import CustomHTTPException
 from flarchitect.utils.response_helpers import create_response
 

--- a/tests/test_model_meta/model_meta/extensions.py
+++ b/tests/test_model_meta/model_meta/extensions.py
@@ -4,7 +4,7 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import DateTime
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
-from flarchitect.core.architect import Architect
+from flarchitect import Architect
 
 
 class BaseModel(DeclarativeBase):


### PR DESCRIPTION
## Summary
- expose `Architect` at the `flarchitect` package root for simpler imports
- update docs, demos and tests to use `from flarchitect import Architect`

## Testing
- `ruff format .`
- `ruff check . --fix`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c4056f9948322938b30641750f857