### PR TITLE
docs: add advanced configuration section

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -1,0 +1,53 @@
+Advanced Configuration
+======================
+
+Beyond the basics, **flarchitect** offers several advanced options for fine-tuning
+API behaviour. This guide covers rate limiting and cache configuration.
+
+Rate limiting
+-------------
+
+Rate limits can be applied globally, per HTTP method or per model.
+
+**Global limit**
+
+.. code:: python
+
+    class Config:
+        API_RATE_LIMIT = "200 per day"
+
+**Method specific**
+
+.. code:: python
+
+    class Config:
+        API_GET_RATE_LIMIT = "100 per minute"
+        API_POST_RATE_LIMIT = "10 per minute"
+
+**Model specific**
+
+.. code:: python
+
+    class Book(db.Model):
+        __tablename__ = "book"
+
+        class Meta:
+            rate_limit = "5 per minute"      # becomes API_RATE_LIMIT
+            get_rate_limit = "10 per minute"  # becomes API_GET_RATE_LIMIT
+
+Caching backends
+----------------
+
+The rate limiter stores counters in a cache backend. When initialising,
+``flarchitect`` will automatically use a locally running Memcached,
+Redis or MongoDB instance. To point to a specific backend, supply a
+storage URI:
+
+.. code:: python
+
+    class Config:
+        API_RATE_LIMIT_STORAGE_URI = "redis://redis.example.com:6379"
+
+If no backend is available, the limiter falls back to in-memory storage
+with rate-limit headers enabled by default.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ flarchitect
    authentication
    callbacks
    configuration
+   advanced_configuration
    openapi
    faq
    genindex

--- a/tests/test_rate_limit_services.py
+++ b/tests/test_rate_limit_services.py
@@ -1,0 +1,59 @@
+"""Tests for rate limit service utilities."""
+
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+from flarchitect.utils.general import (
+    check_rate_prerequisites,
+    check_rate_services,
+)
+
+
+class TestRateLimitServices:
+    """Validate rate limit storage detection and prerequisites."""
+
+    def test_returns_config_uri(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Use configured storage URI when provided."""
+
+        # Provide a custom storage URI via configuration helper.
+        monkeypatch.setattr(
+            "flarchitect.utils.general.get_config_or_model_meta",
+            lambda key, default=None, model=None: "redis://127.0.0.1:6379",
+        )
+
+        assert check_rate_services() == "redis://127.0.0.1:6379"
+
+    def test_returns_none_without_services(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Return ``None`` when no cache services are reachable."""
+
+        monkeypatch.setattr(
+            "flarchitect.utils.general.get_config_or_model_meta",
+            lambda key, default=None, model=None: None,
+        )
+
+        class DummySocket:
+            def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple init
+                """Placeholder socket that always fails to connect."""
+
+            def settimeout(self, value: float) -> None:  # pragma: no cover
+                pass
+
+            def connect(self, address: tuple[str, int]) -> None:
+                raise OSError
+
+            def close(self) -> None:  # pragma: no cover
+                pass
+
+        monkeypatch.setattr("flarchitect.utils.general.socket.socket", lambda *a, **k: DummySocket())
+
+        assert check_rate_services() is None
+
+    def test_prerequisites_missing_dependency(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Raise ``ImportError`` if required client library is absent."""
+
+        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+        with pytest.raises(ImportError):
+            check_rate_prerequisites("Redis")


### PR DESCRIPTION
## Summary
- document advanced rate limiting and cache configuration options
- test rate limit service detection and prerequisites

## Testing
- `ruff check flarchitect tests/test_rate_limit_services.py`
- `pytest tests/test_rate_limit_services.py tests/test_functions.py`
- `pytest` *(fails: tests/test_api_filters.py::test_advanced_filter)*

------
https://chatgpt.com/codex/tasks/task_e_689c41dfdbf48322a20d919745f56d6f