### PR TITLE
Document and test schema field validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQ
 - **Built-in authentication** – ship with JWT, basic and API key strategies out of the box, or plug in your own authentication.
 - **Rate limiting & structured responses** – configurable throttling and responses with a consistent schema.
 - **Highly configurable** – tweak behaviour globally via Flask config or per model with `Meta` attributes.
+- **Field validation** – built-in validators for emails, URLs, IPs and more.
 - **Nested writes** – opt-in support for sending related objects in POST/PUT payloads. Enable with `API_ALLOW_NESTED_WRITES = True` and let `AutoSchema` deserialize them automatically.
 
 ## Installation

--- a/demo/model_extension/model/models.py
+++ b/demo/model_extension/model/models.py
@@ -188,7 +188,7 @@ class Publisher(db.Model):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String)
-    website: Mapped[str] = mapped_column(String)
+    website: Mapped[str] = mapped_column(String, info={"format": "uri"})
     email: Mapped[str | None] = mapped_column(
         String,
         info={

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ flarchitect
    installation
    quickstart
    models
+   validation
    authentication
    callbacks
    configuration

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -1,0 +1,58 @@
+Validation
+==========
+
+flarchitect ships with a suite of field validators that hook directly into
+`Marshmallow`_.  Validators can be attached to a model column via the SQLAlchemy
+``info`` mapping or inferred automatically from column names and formats.
+
+Basic usage
+-----------
+
+.. code-block:: python
+
+    class Author(db.Model):
+        email = db.Column(
+            db.String,
+            info={"validate": "email"},
+        )
+        website = db.Column(
+            db.String,
+            info={"format": "uri"},  # auto adds URL validation
+        )
+
+When invalid data is sent to the API a ``400`` response is returned:
+
+.. code-block:: json
+
+    {
+      "errors": {"error": {"email": ["Email address is not valid."]}},
+      "status_code": 400,
+      "value": null
+    }
+
+Available validators
+--------------------
+
+``validate_by_type`` supports the following names:
+
+* ``email``
+* ``url``
+* ``ipv4``
+* ``ipv6``
+* ``mac``
+* ``slug``
+* ``uuid``
+* ``card``
+* ``country_code``
+* ``domain``
+* ``md5``
+* ``sha1``
+* ``sha256``
+* ``sha512``
+* ``date``
+* ``datetime``
+* ``time``
+* ``boolean``
+* ``decimal``
+
+.. _Marshmallow: https://marshmallow.readthedocs.io/

--- a/flarchitect/schemas/validators.py
+++ b/flarchitect/schemas/validators.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Iterable
 from datetime import date, datetime, time
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 import validators
 from marshmallow import ValidationError
@@ -128,7 +128,7 @@ def validate_decimal(value: str | int | float | Decimal) -> bool:
     try:
         Decimal(value)
         return True
-    except ValueError as err:
+    except (ValueError, InvalidOperation) as err:  # type: ignore[name-defined]
         raise ValidationError("Invalid decimal number.") from err
 
 
@@ -214,5 +214,6 @@ def validate_by_type(validator_type: str) -> Callable[[str], None] | None:
         ),
         "time": validate_time,
         "boolean": validate_boolean,
+        "decimal": validate_decimal,
     }
     return validation_map.get(validator_type)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -82,6 +82,15 @@ def test_invalid_type_datatype_two(client_models):
     patch_resp = client_models.patch("/api/publishers/1", json=data)
 
     assert patch_resp.status_code == 400
-    assert (
-        patch_resp.json["errors"]["error"]["email"][0] == "Email address is not valid."
-    )
+    assert patch_resp.json["errors"]["error"]["email"][0] == "Email address is not valid."
+
+
+def test_invalid_url(client_models):
+    """Invalid URLs return a clear validation error."""
+    publisher = client_models.get("/api/publishers/1").json
+    data = publisher["value"]
+    data["website"] = "not-a-url"
+    resp = client_models.patch("/api/publishers/1", json=data)
+
+    assert resp.status_code == 400
+    assert resp.json["errors"]["error"]["website"][0] == "URL is not valid."

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,85 @@
+import uuid
+
+import pytest
+from marshmallow import ValidationError
+
+from flarchitect.schemas.validators import (
+    validate_boolean,
+    validate_by_type,
+    validate_date,
+    validate_datetime,
+    validate_decimal,
+    validate_time,
+)
+
+
+@pytest.mark.parametrize(
+    "validator,value",
+    [
+        (validate_datetime, "2024-01-01T12:00:00"),
+        (validate_date, "2024-01-01"),
+        (validate_time, "23:59:59"),
+        (validate_decimal, "10.5"),
+        (validate_boolean, "true"),
+    ],
+)
+def test_custom_validators_success(validator, value):
+    """Custom validators accept expected values."""
+    assert validator(value) is True
+
+
+@pytest.mark.parametrize(
+    "validator,value",
+    [
+        (validate_datetime, "2024/01/01 12:00:00"),
+        (validate_date, "20240101"),
+        (validate_time, "24:00:00"),
+        (validate_decimal, "abc"),
+        (validate_boolean, "maybe"),
+    ],
+)
+def test_custom_validators_failure(validator, value):
+    """Custom validators raise ``ValidationError`` for bad input."""
+    with pytest.raises(ValidationError):
+        validator(value)
+
+
+@pytest.mark.parametrize(
+    "vtype,valid,invalid",
+    [
+        ("email", "user@example.com", "not-email"),
+        ("url", "https://example.com", "not-url"),
+        ("ipv4", "192.168.1.1", "256.256.256.256"),
+        ("ipv6", "2001:0db8:85a3:0000:0000:8a2e:0370:7334", "invalid"),
+        ("mac", "00:1B:44:11:3A:B7", "invalid"),
+        ("slug", "my-slug", "My Slug"),
+        ("uuid", str(uuid.uuid4()), "not-uuid"),
+        ("card", "4111111111111111", "1234"),
+        ("country_code", "US", "XX"),
+        ("domain", "example.com", "example"),
+        ("md5", "d41d8cd98f00b204e9800998ecf8427e", "xyz"),
+        ("sha1", "da39a3ee5e6b4b0d3255bfef95601890afd80709", "xyz"),
+        (
+            "sha256",
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "xyz",
+        ),
+        (
+            "sha512",
+            "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
+            "xyz",
+        ),
+        ("date", "2024-01-01", "20240101"),
+        ("datetime", "2024-01-01 12:00:00", "2024/01/01 12:00:00"),
+        ("time", "23:59:59", "24:00:00"),
+        ("boolean", "true", "maybe"),
+        ("decimal", "10.5", "abc"),
+    ],
+)
+def test_validate_by_type(vtype, valid, invalid):
+    """``validate_by_type`` returns a callable enforcing each type."""
+    validator = validate_by_type(vtype)
+    assert validator is not None
+    validator(valid)
+    with pytest.raises(ValidationError):
+        validator(invalid)


### PR DESCRIPTION
## Summary
- extend decimal validation to raise proper errors and expose a `decimal` validator option
- cover validator success and failure paths with unit tests and API URL validation
- document available field validators and mention them in project features

## Testing
- `ruff check tests/test_validators.py tests/test_exceptions.py demo/model_extension/model/models.py --fix`
- `ruff format tests/test_validators.py tests/test_exceptions.py demo/model_extension/model/models.py`
- `pytest tests/test_validators.py tests/test_exceptions.py`

------
https://chatgpt.com/codex/tasks/task_e_689c415201408322b4a720be54b76306