### PR TITLE
refactor: remove obsolete CustomResponse wrapper

### DIFF
--- a/flarchitect/utils/general.py
+++ b/flarchitect/utils/general.py
@@ -402,16 +402,15 @@ def xml_to_dict(xml_data: str | bytes) -> dict[str, Any]:
 
 
 def handle_result(result: Any) -> tuple[int, Any, int, str | None, str | None]:
+    """Process a route result for standardised API responses.
+
+    Args:
+        result: Output produced by a route handler.
+
+    Returns:
+        tuple[int, Any, int, str | None, str | None]:
+            Status code, value, total count, next URL and previous URL.
     """
-    Processes the result of a route function
-    and prepares it for the standardised response.
-    """
-
-    # todo really not sure why this is here again.
-    # Its a relic from the past, a lot of this needs looking at.
-
-    from flarchitect.utils.responses import CustomResponse
-
     status_code, value, count, next_url, previous_url = HTTP_OK, result, 1, None, None
 
     if isinstance(result, tuple):
@@ -423,18 +422,20 @@ def handle_result(result: Any) -> tuple[int, Any, int, str | None, str | None]:
             if len(result) == 2 and isinstance(result[1], int)
             else (HTTP_OK, result)
         )
+
     if isinstance(result, dict):
-        value, count = (
-            result.get("query", result),
-            get_count(result, result.get("query")),
-        )
-        next_url, previous_url = result.get("next_url"), result.get("previous_url")
-    elif isinstance(result, CustomResponse):
-        next_url, previous_url, count = (
-            result.next_url,
-            result.previous_url,
-            result.count,
-        )
+        if "value" in result and "count" in result:
+            value = result.get("value")
+            count = result.get("count", count)
+            next_url, previous_url = result.get("next_url"), result.get("previous_url")
+            status_code = result.get("status_code", status_code)
+        else:
+            value, count = (
+                result.get("query", result),
+                get_count(result, result.get("query")),
+            )
+            next_url, previous_url = result.get("next_url"), result.get("previous_url")
+            status_code = result.get("status_code", status_code)
 
     return status_code, value, count, next_url, previous_url
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -1,0 +1,32 @@
+from marshmallow import Schema, fields
+
+from flarchitect.utils.general import HTTP_OK, handle_result
+from flarchitect.utils.responses import serialize_output_with_mallow
+
+
+class ItemSchema(Schema):
+    """Schema for testing serialisation."""
+
+    id = fields.Int(required=True)
+
+
+class TestSerializeOutputWithMallow:
+    """Tests for the ``serialize_output_with_mallow`` helper."""
+
+    def test_serialization_returns_dict(self):
+        """Serialising data produces a dictionary with value and count."""
+        data = {"id": 1}
+        result = serialize_output_with_mallow(ItemSchema(), data)
+        assert result["value"] == {"id": 1}
+        assert result["count"] == 1
+
+    def test_handle_result_processes_serialized_output(self):
+        """``handle_result`` correctly interprets serialised dictionaries."""
+        data = {"id": 1}
+        result = serialize_output_with_mallow(ItemSchema(), data)
+        status, value, count, next_url, previous_url = handle_result(result)
+        assert status == HTTP_OK
+        assert value == {"id": 1}
+        assert count == 1
+        assert next_url is None
+        assert previous_url is None


### PR DESCRIPTION
## Summary
- drop unused `CustomResponse` class and replace with simple dict serialization
- update result handling to work with dict responses
- add unit tests for serialisation helper and result handling

## Testing
- `ruff format tests/test_responses.py flarchitect/utils/general.py flarchitect/utils/responses.py`
- `ruff check tests/test_responses.py flarchitect/utils/general.py flarchitect/utils/responses.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'apispec')*


------
https://chatgpt.com/codex/tasks/task_e_689cb5bb8328832283f6d03a9fdcd969