### PR TITLE
Add optional Swagger UI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ if __name__ == "__main__":
 ## OpenAPI specification
 
 An OpenAPI 3 schema is generated automatically and powers the Redoc UI. You
-can serve the raw specification to integrate with tooling such as Postman:
+can switch to Swagger‑UI by setting ``API_DOCS_STYLE = 'swagger'`` in your Flask
+config. Either way you can serve the raw specification to integrate with
+tooling such as Postman:
 
 ```python
 from flask import Flask, Response, jsonify

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,7 +40,7 @@ flarchitect
 
 
 
-**flarchitect** turns your `SQLAlchemy`_ models into a polished RESTful API complete with interactive `Redoc`_ documentation.
+**flarchitect** turns your `SQLAlchemy`_ models into a polished RESTful API complete with interactive `Redoc`_ or Swagger UI documentation.
 Hook it into your `Flask`_ application and you'll have endpoints, schemas and docs in moments.
 
 What can it do?
@@ -50,7 +50,7 @@ What can it do?
 * Authenticate users with JWT access and refresh tokens.
 * Add configurable rate limits backed by Redis, Memcached or MongoDB.
 * Be configured globally in `Flask`_ or per model via ``Meta`` attributes.
-* Generate `Redoc`_ documentation on the fly.
+* Generate `Redoc`_ or Swagger UI documentation on the fly.
 
 What are you waiting for...?
 

--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -3,7 +3,9 @@ OpenAPI Specification
 
 flarchitect automatically generates an OpenAPI 3.0.2 document for every
 registered model. The specification powers the interactive Redoc page and
-can also be reused with external tools like Postman or Swagger UI.
+can also be rendered with Swagger UI by setting ``API_DOCS_STYLE = 'swagger'``
+in your Flask configuration. The raw spec can also be reused with external
+tools like Postman.
 
 Automatic generation
 --------------------

--- a/flarchitect/html/swagger.html
+++ b/flarchitect/html/swagger.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{{config.API_TITLE}} v{{config.API_VERSION}}</title>
+    <meta charset="utf-8"/>
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    {{custom_headers|safe}}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.14/swagger-ui.css" />
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.14/swagger-ui-bundle.js"></script>
+<script>
+    SwaggerUIBundle({
+        url: '/swagger.json',
+        dom_id: '#swagger-ui'
+    });
+</script>
+</body>
+{{custom_footers|safe}}
+</html>

--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -249,10 +249,11 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
             Returns:
                 str: The HTML documentation page.
             """
-
             custom_headers = get_config_or_model_meta("API_DOCUMENTATION_HEADERS", default="") or self._get_config("API_DOC_HTML_HEADERS", "")
+            docs_style = get_config_or_model_meta("API_DOCS_STYLE", default="redoc").lower()
+            template_name = "swagger.html" if docs_style == "swagger" else "apispec.html"
             return manual_render_absolute_template(
-                os.path.join(self.architect.get_templates_path(), "apispec.html"),
+                os.path.join(self.architect.get_templates_path(), template_name),
                 config=self.app.config,
                 custom_headers=custom_headers,
             )

--- a/tests/test_swagger_ui.py
+++ b/tests/test_swagger_ui.py
@@ -1,0 +1,9 @@
+from demo.basic_factory.basic_factory import create_app
+
+
+def test_swagger_docs_served():
+    app = create_app({"API_DOCS_STYLE": "swagger"})
+    client = app.test_client()
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+    assert "SwaggerUIBundle" in resp.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- add Swagger UI template and allow choosing docs style via `API_DOCS_STYLE`
- mention new configuration in docs and README
- cover Swagger UI rendering with smoke test

## Testing
- `ruff check . --fix`
- `ruff format flarchitect/specs/generator.py tests/test_swagger_ui.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689cb5c6cb488322b98c8730000f9110