### PR TITLE
Add optional CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQ
 - **SQLAlchemy integration** – works with plain SQLAlchemy or Flask-SQLAlchemy.
 - **Built-in authentication** – ship with JWT, basic and API key strategies out of the box, or plug in your own authentication.
 - **Rate limiting & structured responses** – configurable throttling and responses with a consistent schema.
+- **CORS support** – enable Cross-Origin Resource Sharing with `API_ENABLE_CORS`.
 - **Highly configurable** – tweak behaviour globally via Flask config or per model with `Meta` attributes.
 - **Field validation** – built-in validators for emails, URLs, IPs and more.
 - **Nested writes** – opt-in support for sending related objects in POST/PUT payloads. Enable with `API_ALLOW_NESTED_WRITES = True` and let `AutoSchema` deserialize them automatically.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -246,3 +246,17 @@ Documentation Configuration Values
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
         - Enable POST/PATCH requests to include nested related objects.
+    * - .. data:: ENABLE_CORS
+          :bdg:`default:` ``False``
+          :bdg:`type` ``bool``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+        - Enable Cross-Origin Resource Sharing by calling ``flask_cors.CORS``.
+          Resources may be customised via :data:`CORS_RESOURCES`.
+
+    * - .. data:: CORS_RESOURCES
+          :bdg:`default:` ``None``
+          :bdg:`type` ``dict | list[str]``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+        - Resource patterns passed to :func:`flask_cors.CORS`.
+          Follows the ``resources`` parameter format from ``flask-cors``.
+

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Optional, TypeVar, cast
 
 from flask import Flask, request
+from flask_cors import CORS
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from marshmallow import Schema
@@ -86,7 +87,7 @@ class Architect(AttributeInitializerMixin):
             self.init_app(app, *args, **kwargs)
             logger.verbosity_level = self.get_config("API_VERBOSITY_LEVEL", 0)
 
-    def init_app(self, app: Flask, *args, **kwargs):
+    def init_app(self, app: Flask, *args, **kwargs) -> None:
         """
         Initializes the Architect object.
 
@@ -97,6 +98,8 @@ class Architect(AttributeInitializerMixin):
         """
         super().__init__(app, *args, **kwargs)
         self._register_app(app)
+        if self.get_config("API_ENABLE_CORS", False):
+            CORS(app, resources=app.config.get("CORS_RESOURCES"))
         logger.verbosity_level = self.get_config("API_VERBOSITY_LEVEL", 0)
         self.api_spec = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "colorama>=0.4.6",
     "dicttoxml>=1.7.16",
     "flask>=2.2.5",
+    "flask-cors>=4.0.0",
     "flask-jwt-extended>=4.6.0",
     "flask-limiter>=3.5.0",
     "flask-login>=0.6.3",

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,16 @@
+"""Tests for Cross-Origin Resource Sharing (CORS) support."""
+
+from demo.model_extension.model import create_app
+
+
+def test_cors_headers():
+    """Ensure CORS headers are included when enabled."""
+    app = create_app(
+        {
+            "API_ENABLE_CORS": True,
+            "CORS_RESOURCES": {r"/api/*": {"origins": "http://example.com"}},
+        }
+    )
+    client = app.test_client()
+    response = client.get("/api/authors", headers={"Origin": "http://example.com"})
+    assert response.headers["Access-Control-Allow-Origin"] == "http://example.com"


### PR DESCRIPTION
## Summary
- enable CORS via new `API_ENABLE_CORS` flag and optional `CORS_RESOURCES` mapping
- document CORS configuration and install `flask-cors`
- test CORS headers

## Testing
- `ruff check --fix flarchitect/core/architect.py tests/test_cors.py`
- `ruff format pyproject.toml` *(failed: README.md/docs parse errors)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cb5d72c7c832294d462853e46ca1d