### PR TITLE
Implement basic and API key login routes with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQ
 - **Zero-configuration endpoints** – expose models as RESTful resources by adding a simple `Meta` class.
 - **Automatic documentation** – comprehensive Redoc docs are generated at runtime and stay in sync with your models.
 - **SQLAlchemy integration** – works with plain SQLAlchemy or Flask-SQLAlchemy.
-- **Built-in authentication** – ship with JWT, basic and API key strategies out of the box, or plug in your own authentication.
+- **Built-in authentication** – ship with JWT, basic and API key strategies out of the box, each exposing a simple `/auth/login` endpoint for credential validation, or plug in your own authentication.
 - **Rate limiting & structured responses** – configurable throttling and responses with a consistent schema.
 - **Highly configurable** – tweak behaviour globally via Flask config or per model with `Meta` attributes.
 - **Field validation** – built-in validators for emails, URLs, IPs and more.

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -72,6 +72,14 @@ Provide a lookup field and password check method on your user model:
        API_USER_LOOKUP_FIELD = "username"
        API_CREDENTIAL_CHECK_METHOD = "check_password"
 
+flarchitect also provides a simple login route for this strategy. POST to
+``/auth/login`` with a ``Basic`` ``Authorization`` header to verify
+credentials and receive basic user information:
+
+.. code-block:: bash
+
+   curl -X POST -u username:password http://localhost:5000/auth/login
+
 You can then access endpoints with tools such as ``curl``:
 
 .. code-block:: bash
@@ -102,6 +110,14 @@ also call ``set_current_user``:
    class Config(BaseConfig):
        API_AUTHENTICATE_METHOD = ["api_key"]
        API_KEY_AUTH_AND_RETURN_METHOD = staticmethod(lookup_user_by_token)
+
+When this method is enabled flarchitect exposes a companion login route. POST
+an ``Api-Key`` ``Authorization`` header to ``/auth/login`` to validate the key
+and retrieve basic user details:
+
+.. code-block:: bash
+
+   curl -X POST -H "Authorization: Api-Key <token>" http://localhost:5000/auth/login
 
 Example request:
 


### PR DESCRIPTION
## Summary
- implement basic and API key login routes validating credentials and returning user info
- add unit tests for basic and API key login endpoints
- document new `/auth/login` endpoints for basic and API key strategies

## Testing
- `ruff check --fix flarchitect/core/routes.py tests/test_authentication.py`
- `ruff format flarchitect/core/routes.py tests/test_authentication.py`
- `pytest tests/test_authentication.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb5b670a883228ec7a68d3a25df96