### PR TITLE
docs: update error field examples

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -81,7 +81,7 @@ Into this:
       "total_count": 10,
       "next_url": "/api/authors?limit=2&page=3",
       "previous_url": "/api/authors?limit=2&page=1",
-      "error": "null",
+      "errors": null,
       "value": [
         {
           "author": "John Doe",

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -25,7 +25,7 @@ When invalid data is sent to the API a ``400`` response is returned:
 .. code-block:: json
 
     {
-      "errors": {"error": {"email": ["Email address is not valid."]}},
+      "errors": {"email": ["Email address is not valid."]},
       "status_code": 400,
       "value": null
     }


### PR DESCRIPTION
## Summary
- replace `error` with `errors` in response examples
- adjust validation docs to show field-level error messages

## Testing
- `ruff format docs/source/index.rst docs/source/validation.rst` (failed: Expected a statement)
- `ruff check flarchitect tests` (failed: SIM118 Use `key in dict` ...)
- `cd docs && make html`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc97bf0588322ad1c5113460a1bc2