### PR TITLE
docs: add CORS configuration guidance

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -51,3 +51,25 @@ storage URI:
 If no backend is available, the limiter falls back to in-memory storage
 with rate-limit headers enabled by default.
 
+CORS
+----
+
+To enable `Cross-Origin Resource Sharing (CORS) <https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS>`_
+for your API, set :data:`API_ENABLE_CORS` to ``True`` in the application
+configuration. When active, CORS headers are applied to matching routes
+defined in :data:`CORS_RESOURCES`.
+
+``CORS_RESOURCES`` accepts a mapping of URL patterns to their respective
+options, mirroring the format used by `Flask-CORS <https://flask-cors.readthedocs.io/>`_.
+
+.. code:: python
+
+    class Config:
+        API_ENABLE_CORS = True
+        CORS_RESOURCES = {
+            r"/api/*": {"origins": "*"}
+        }
+
+See the :doc:`configuration <configuration>` page for the full list of
+available CORS settings.
+


### PR DESCRIPTION
## Summary
- document enabling CORS via `API_ENABLE_CORS`
- show example `CORS_RESOURCES` mapping
- point to configuration docs for additional CORS options

## Testing
- `ruff format docs/source/advanced_configuration.rst` *(fails: Failed to parse docs/source/advanced_configuration.rst:1:10: Simple statements must be separated by newlines or semicolons)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cc99e0d508322a42414879cf88530