### PR TITLE
docs: add authentication error examples and troubleshooting table

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -6,6 +6,39 @@ Enable one or more strategies via ``API_AUTHENTICATE_METHOD``. Available
 methods are ``jwt``, ``basic``, ``api_key`` and ``custom``. Each example below
 uses the common setup defined in ``demo/authentication/app_base.py``.
 
+Error responses
+---------------
+
+Missing or invalid credentials return a ``401`` response:
+
+.. code-block:: json
+
+    {
+      "errors": {"error": "Authorization header missing"},
+      "status_code": 401,
+      "value": null
+    }
+
+Expired tokens also yield a ``401``:
+
+.. code-block:: json
+
+    {
+      "errors": {"error": "Token has expired"},
+      "status_code": 401,
+      "value": null
+    }
+
+Refresh failures, such as an invalid refresh token, respond with ``403``:
+
+.. code-block:: json
+
+    {
+      "errors": {"error": "Invalid or expired refresh token"},
+      "status_code": 403,
+      "value": null
+    }
+
 JWT authentication
 ------------------
 
@@ -156,3 +189,18 @@ Clients can then call your API with whatever headers your function expects:
    curl -H "X-Token: <token>" http://localhost:5000/api/books
 
 See ``demo/authentication/custom_auth.py`` for this approach in context.
+
+Troubleshooting
+---------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Problem
+     - Solution
+   * - Missing Authorization header
+     - Include the appropriate ``Authorization`` header with your credentials.
+   * - Token has expired
+     - Use the refresh token to obtain a new access token.
+   * - Invalid or expired refresh token
+     - Log in again to receive a new access/refresh token pair.


### PR DESCRIPTION
## Summary
- document JSON error responses for missing credentials, expired tokens, and refresh issues
- add authentication troubleshooting table

## Testing
- `pre-commit run --files docs/source/authentication.rst` *(fails: `.pre-commit-config.yaml` is not a file)*
- `pytest tests/test_authentication.py`


------
https://chatgpt.com/codex/tasks/task_e_689ccaaf35a48322b495b9fa91892e1d