### PR TITLE
Fix badge rendering in configuration docs

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -1,318 +1,460 @@
 .. list-table::
 
-    * - .. data:: API_CREATE_DOCS
+    * - ``API_CREATE_DOCS``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DOCUMENTATION_URL
+    * - ``API_DOCUMENTATION_URL``
+
           :bdg:`default:` ``/docs``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - The url of the docs  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_TITLE
+    * - ``API_TITLE``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-danger:`Required` :bdg-dark-line:`Global`
+
         - The title of the docs  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_VERSION
+    * - ``API_VERSION``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-danger:`Required` :bdg-dark-line:`Global`
+
         - The version no of the docs  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_LOGO_URL
+    * - ``API_LOGO_URL``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - The logo to display in the docs  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_LOGO_BACKGROUND
+    * - ``API_LOGO_BACKGROUND``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - The background colour of the area where the logo is  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DESCRIPTION
+    * - ``API_DESCRIPTION``
+
           :bdg:`type` ``str or str path``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Accepts a string or a filepath string, with a default behavior that auto-generates a comprehensive documentation description.   If a filepath is provided, it can point to a Jinja template that dynamically accesses the Flask configuration via {config.xxxx} placeholders. This flexible approach allows for a rich, context-aware description in your ReDoc documentation.  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_KEYWORDS
+    * - ``API_KEYWORDS``
+
           :bdg:`default:` ``None``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - 
-    * - .. data:: API_CONTACT_NAME
+    * - ``API_CONTACT_NAME``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Specifies the contact name for inquiries and support in the redoc documentation. If not provided, the field name will not be displayed in the docs.  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_CONTACT_EMAIL
+    * - ``API_CONTACT_EMAIL``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Specifies the contact email for inquiries and support in the redoc documentation. If not provided, the field name will not be displayed in the docs.  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_CONTACT_URL
+    * - ``API_CONTACT_URL``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Specifies the contact url for inquiries and support in the redoc documentation. If not provided, the field name will not be displayed in the docs.  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_LICENCE_NAME
+    * - ``API_LICENCE_NAME``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Specifies the licence name in the redoc documentation. If not provided, the field name will not be displayed in the docs.  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_LICENCE_URL
+    * - ``API_LICENCE_URL``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Specifies the licence url in the redoc documentation. If not provided, the field name will not be displayed in the docs.  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_SERVER_URLS
+    * - ``API_SERVER_URLS``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``list[dict]``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - example: [{"url": "http://localhost:5000", "description": "Local server"}...]  Specifies the server(s) used for   calling the API in the redoc documentation. If not provided, the field name will not be displayed in the docs.  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DOC_HTML_HEADERS
+    * - ``API_DOC_HTML_HEADERS``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - custom headers to be added to the documentation page.  Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DOC_HTML_FOOTERS
+    * - ``API_DOC_HTML_FOOTERS``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - custom footers to be added to the documentation page.
-    * - .. data:: API_PREFIX
+    * - ``API_PREFIX``
+
           :bdg:`default:` ``/api``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_VERBOSITY_LEVEL
+    * - ``API_VERBOSITY_LEVEL``
+
           :bdg:`default:` ``1``
           :bdg:`type` ``int``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_model_meta/model_meta/config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_model_meta/model_meta/config.py>`_.
-    * - .. data:: API_ENDPOINT_CASE
+    * - ``API_ENDPOINT_CASE``
+
           :bdg:`default:` ``kebab``
           :bdg:`type` ``string``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_FIELD_CASE
+    * - ``API_FIELD_CASE``
+
           :bdg:`default:` ``snake``
           :bdg:`type` ``string``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_SCHEMA_CASE
+    * - ``API_SCHEMA_CASE``
+
           :bdg:`default:` ``camel``
           :bdg:`type` ``string``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_PRINT_EXCEPTIONS
+    * - ``API_PRINT_EXCEPTIONS``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - 
-    * - .. data:: API_BASE_SCHEMA
+    * - ``API_BASE_SCHEMA``
+
           :bdg:`default:` ``AutoSchema``
           :bdg:`type` ``Schema``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - 
-    * - .. data:: API_ALLOW_CASCADE_DELETE
+    * - ``API_ALLOW_CASCADE_DELETE``
+
           :bdg-secondary:`Optional` 
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_IGNORE_UNDERSCORE_ATTRIBUTES
+    * - ``API_IGNORE_UNDERSCORE_ATTRIBUTES``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_SERIALIZATION_TYPE
+    * - ``API_SERIALIZATION_TYPE``
+
           :bdg-secondary:`Optional` 
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_SERIALIZATION_DEPTH
+    * - ``API_SERIALIZATION_DEPTH``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: API_DUMP_HYBRID_PROPERTIES
+    * - ``API_DUMP_HYBRID_PROPERTIES``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_ADD_RELATIONS
+    * - ``API_ADD_RELATIONS``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_PAGINATION_SIZE_DEFAULT
+    * - ``API_PAGINATION_SIZE_DEFAULT``
+
           :bdg:`default:` ``20``
           :bdg:`type` ``int``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_api_filters.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_api_filters.py>`_.
-    * - .. data:: API_PAGINATION_SIZE_MAX
+    * - ``API_PAGINATION_SIZE_MAX``
+
           :bdg:`default:` ``100``
           :bdg:`type` ``int``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - 
-    * - .. data:: API_READ_ONLY
+    * - ``API_READ_ONLY``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_ALLOW_ORDER_BY
+    * - ``API_ALLOW_ORDER_BY``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_ALLOW_FILTER
+    * - ``API_ALLOW_FILTER``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_ALLOW_JOIN
+    * - ``API_ALLOW_JOIN``
+
           :bdg-secondary:`Optional` 
+
         - IN DEVELOPMENT
-    * - .. data:: API_ALLOW_GROUPBY
+    * - ``API_ALLOW_GROUPBY``
+
           :bdg-secondary:`Optional` 
+
         - IN DEVELOPMENT
-    * - .. data:: API_ALLOW_AGGREGATION
+    * - ``API_ALLOW_AGGREGATION``
+
           :bdg-secondary:`Optional` 
+
         - IN DEVELOPMENT
-    * - .. data:: API_ALLOW_SELECT_FIELDS
+    * - ``API_ALLOW_SELECT_FIELDS``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_block_methods
+    * - ``API_block_methods``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: API_AUTHENTICATE
+    * - ``API_AUTHENTICATE``
+
           :bdg-secondary:`Optional` 
+
         - Example: `tests/test_authentication.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_authentication.py>`_.
-    * - .. data:: API_AUTHENTICATE_METHOD
+    * - ``API_AUTHENTICATE_METHOD``
+
           :bdg-secondary:`Optional` 
+
         - Example: `tests/test_authentication.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_authentication.py>`_.
-    * - .. data:: API_USER_MODEL
+    * - ``API_USER_MODEL``
+
           :bdg-secondary:`Optional` 
+
         - Example: `tests/test_authentication.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_authentication.py>`_.
-    * - .. data:: API_SETUP_CALLBACK
+    * - ``API_SETUP_CALLBACK``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``callable``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_RETURN_CALLBACK
+    * - ``API_RETURN_CALLBACK``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``callable``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_ERROR_CALLBACK
+    * - ``API_ERROR_CALLBACK``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``callable``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_POST_DUMP_CALLBACK
+    * - ``API_POST_DUMP_CALLBACK``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``callable``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
         - 
-    * - .. data:: API_ADDITIONAL_QUERY_PARAMS
+    * - ``API_ADDITIONAL_QUERY_PARAMS``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``list[dict]``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DUMP_DATETIME
+    * - ``API_DUMP_DATETIME``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DUMP_VERSION
+    * - ``API_DUMP_VERSION``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DUMP_STATUS_CODE
+    * - ``API_DUMP_STATUS_CODE``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DUMP_RESPONSE_TIME
+    * - ``API_DUMP_RESPONSE_TIME``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - 
-    * - .. data:: API_DUMP_COUNT
+    * - ``API_DUMP_COUNT``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - 
-    * - .. data:: API_DUMP_NULL_NEXT_URL
+    * - ``API_DUMP_NULL_NEXT_URL``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DUMP_NULL_PREVIOUS_URL
+    * - ``API_DUMP_NULL_PREVIOUS_URL``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_DUMP_NULL_ERROR
+    * - ``API_DUMP_NULL_ERROR``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_RATE_LIMIT
+    * - ``API_RATE_LIMIT``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
         - Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - .. data:: API_RATE_LIMIT_CALLBACK
+    * - ``API_RATE_LIMIT_CALLBACK``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: API_RATE_LIMIT_STORAGE_URI
+    * - ``API_RATE_LIMIT_STORAGE_URI``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - 
-    * - .. data:: IGNORE_FIELDS
+    * - ``IGNORE_FIELDS``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: IGNORE_OUTPUT_FIELDS
+    * - ``IGNORE_OUTPUT_FIELDS``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: IGNORE_INPUT_FIELDS
+    * - ``IGNORE_INPUT_FIELDS``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: API_BLUEPRINT_NAME
+    * - ``API_BLUEPRINT_NAME``
+
           :bdg:`default:` ``None``
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: API_SOFT_DELETE
+    * - ``API_SOFT_DELETE``
+
           :bdg:`default:` ``False``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `demo/soft_delete/soft_delete/config.py <https://github.com/arched-dev/flarchitect/blob/master/demo/soft_delete/soft_delete/config.py>`_.
-    * - .. data:: API_SOFT_DELETE_ATTRIBUTE
+    * - ``API_SOFT_DELETE_ATTRIBUTE``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `demo/soft_delete/soft_delete/config.py <https://github.com/arched-dev/flarchitect/blob/master/demo/soft_delete/soft_delete/config.py>`_.
-    * - .. data:: API_SOFT_DELETE_VALUES
+    * - ``API_SOFT_DELETE_VALUES``
+
           :bdg:`default:` ``None``
           :bdg:`type` ``tuple``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
         - Example: `demo/soft_delete/soft_delete/config.py <https://github.com/arched-dev/flarchitect/blob/master/demo/soft_delete/soft_delete/config.py>`_.
-    * - .. data:: API_ALLOW_DELETE_RELATED
+    * - ``API_ALLOW_DELETE_RELATED``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
         - 
-    * - .. data:: API_ALLOW_DELETE_DEPENDENTS
+    * - ``API_ALLOW_DELETE_DEPENDENTS``
+
           :bdg:`default:` ``True``
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+
         - 
-    * - .. data:: GET_MANY_SUMMARY
+    * - ``GET_MANY_SUMMARY``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: GET_SINGLE_SUMMARY
+    * - ``GET_SINGLE_SUMMARY``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: POST_SUMMARY
+    * - ``POST_SUMMARY``
+
           :bdg-secondary:`Optional` 
+
         - 
-    * - .. data:: PATCH_SUMMARY
+    * - ``PATCH_SUMMARY``
+
           :bdg-secondary:`Optional` 
+
         - 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -25,7 +25,7 @@ Config Hierarchy
 To offer flexibility and control, **flarchitect** follows a hierarchy of configuration priorities:
 
 - **Lowest Priority** – Global `Flask`_ config options apply to all requests and are overridden by any more specific configuration.
-- **Method-based** – Method-specific options can override global settings for particular `HTTP method`_s.
+- **Method-based** – Method-specific options can override global settings for particular HTTP methods.
 - **Model-based** – `SQLAlchemy`_ model ``Meta`` attributes override both global and method-based configurations.
 - **Highest Priority** – Model-specific configurations suffixed with an `HTTP method`_ allow the most detailed customization per model and method.
 
@@ -142,4 +142,4 @@ Please note the badge for each configuration value, as it defines where the valu
 Complete Configuration Reference
 --------------------------------
 
-.. include:: configuration_table.rst
+.. include:: _configuration_table.rst

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -80,5 +80,3 @@ Available validators
 * ``time``
 * ``boolean``
 * ``decimal``
-
-.. _Marshmallow: https://marshmallow.readthedocs.io/


### PR DESCRIPTION
## Summary
- rework configuration table include to use sphinx-design badges
- tidy configuration hierarchy text and include new table file
- remove duplicate Marshmallow link reference

## Testing
- `ruff check .`
- `sphinx-build -E -b html docs/source docs/build/html`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ccd4e4e84832291fb48dd9b4c6c11