### PR TITLE
Document API final callback and add test

### DIFF
--- a/tests/test_response_final_callback.py
+++ b/tests/test_response_final_callback.py
@@ -1,0 +1,31 @@
+"""Tests for the ``API_FINAL_CALLBACK`` configuration option."""
+
+from typing import Any
+
+import pytest
+
+from demo.basic_factory.basic_factory import create_app
+
+
+# Simple callback used to mutate the response payload during tests.
+def _final_callback(data: dict[str, Any]) -> dict[str, Any]:
+    """Add a marker and mutate the title in the response payload."""
+    data["callback_marker"] = True
+    if isinstance(data.get("value"), dict):
+        data["value"]["title"] = "Changed by callback"
+    return data
+
+
+@pytest.fixture
+def client():
+    app = create_app({"API_FINAL_CALLBACK": _final_callback})
+    with app.app_context():
+        yield app.test_client()
+
+
+def test_final_callback_modifies_payload(client):
+    """Ensure the final callback is invoked and mutates the response."""
+    resp = client.get("/api/books/1")
+    assert resp.status_code == 200
+    assert resp.json["callback_marker"] is True
+    assert resp.json["value"]["title"] == "Changed by callback"


### PR DESCRIPTION
## Summary
- document `API_FINAL_CALLBACK` usage and invocation in response helper
- add `test_response_final_callback` to verify payload mutation

## Testing
- `ruff check flarchitect/utils/response_helpers.py tests/test_response_final_callback.py`
- `pytest tests/test_response_final_callback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd3f13630832297b7721c17794250