### PR TITLE
docs: document callbacks validators hooks

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -73,3 +73,73 @@ options, mirroring the format used by `Flask-CORS <https://flask-cors.readthedoc
 See the :doc:`configuration <configuration>` page for the full list of
 available CORS settings.
 
+.. _advanced-callbacks:
+
+Callbacks, validators and hooks
+-------------------------------
+
+``flarchitect`` offers several extension points for tailoring behaviour beyond
+configuration files. These hooks let you alter request handling, apply
+additional field validation and tweak responses on a per-route basis.
+
+Response callbacks
+^^^^^^^^^^^^^^^^^^
+
+Return callbacks run after database operations but before the response is
+serialised. Use them to adjust the output or append metadata.
+
+.. code-block:: python
+
+    from datetime import datetime
+
+    def add_timestamp(model, output, **kwargs):
+        output["generated"] = datetime.utcnow().isoformat()
+        return {"output": output}
+
+    class Config:
+        API_GET_RETURN_CALLBACK = add_timestamp
+
+See :func:`flarchitect.core.routes.create_route_function` for details on how
+responses are constructed.
+
+Custom validators
+^^^^^^^^^^^^^^^^^
+
+Attach validators to SQLAlchemy columns via the ``info`` mapping. Validators are
+looked up in :mod:`flarchitect.schemas.validators` and applied automatically.
+
+.. code-block:: python
+
+    class User(db.Model):
+        email = db.Column(
+            db.String,
+            info={"validator": "email", "validator_message": "Invalid email"},
+        )
+
+See :doc:`validation` for the full list of available validators.
+
+Per-route hooks
+^^^^^^^^^^^^^^^
+
+Execute custom logic before or after a specific route by defining setup or
+return callbacks in configuration or on a model's ``Meta`` class.
+
+.. code-block:: python
+
+    from flask import abort
+    from flask_login import current_user
+
+    def ensure_admin(model, **kwargs):
+        if not current_user.is_admin:
+            abort(403)
+        return kwargs
+
+    class Book(db.Model):
+        class Meta:
+            post_return_callback = add_timestamp
+
+    class Config:
+        API_POST_SETUP_CALLBACK = ensure_admin
+
+For more examples see the :doc:`callbacks` page.
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,6 +52,7 @@ What can it do?
 * Add configurable rate limits backed by Redis, Memcached or MongoDB.
 * Be configured globally in `Flask`_ or per model via ``Meta`` attributes.
 * Generate `Redoc`_ or Swagger UI documentation on the fly.
+* Extend behaviour with response callbacks, custom validators and per-route hooks (:ref:`advanced-callbacks`).
 
 What are you waiting for...?
 


### PR DESCRIPTION
## Summary
- document response callbacks, custom field validators and per-route hooks in advanced configuration docs
- link index to new advanced configuration section

## Testing
- `ruff check flarchitect`
- `pytest` *(fails: Interrupted: 17 errors during collection)*
- `pip install -r docs/requirements.txt`
- `cd docs && make html`


------
https://chatgpt.com/codex/tasks/task_e_689cd41371d08322881c0a69356bd56c