### PR TITLE
feat: add phone and postal code validators

### DIFF
--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -204,6 +204,8 @@ Common ``schema.format`` values include:
 * ``byte``
 * ``binary``
 * ``email``
+* ``phone``
+* ``postal_code``
 * ``uuid``
 * ``uri``
 * ``hostname``

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -75,6 +75,8 @@ Available validators
 * ``cron``
 * ``base64``
 * ``currency``
+* ``phone``
+* ``postal_code``
 * ``date``
 * ``datetime``
 * ``time``

--- a/flarchitect/schemas/bases.py
+++ b/flarchitect/schemas/bases.py
@@ -430,6 +430,10 @@ class AutoSchema(Base):
                     field_args["validate"].append(validate_by_type("sha384"))
                 elif format_name == "currency":
                     field_args["validate"].append(validate_by_type("currency"))
+                elif ("phone" in column_name and column.type.python_type is str) or (format_name in ["phone", "phone_number"]):
+                    field_args["validate"].append(validate_by_type("phone"))
+                elif "postal" in column_name or "zip" in column_name or (format_name in ["postal_code", "zip", "zipcode"]):
+                    field_args["validate"].append(validate_by_type("postal_code"))
             except Exception:
                 pass
 

--- a/flarchitect/schemas/validators.py
+++ b/flarchitect/schemas/validators.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Callable, Iterable
 from datetime import date, datetime, time
 from decimal import Decimal, InvalidOperation
@@ -157,6 +158,44 @@ def validate_boolean(value: bool | str) -> bool:
     raise ValidationError("Invalid boolean value. Accepted values are: True, False, 1, 0, 'true', 'false', 'yes', 'no'.")
 
 
+def validate_phone_number(value: str) -> bool:
+    """Validate that a string represents a phone number.
+
+    Args:
+        value: The phone number string to validate.
+
+    Returns:
+        bool: ``True`` if the value resembles a phone number.
+
+    Raises:
+        ValidationError: If ``value`` is not a valid phone number.
+    """
+
+    pattern = re.compile(r"^\+?[0-9\s\-().]{7,20}$")
+    if pattern.fullmatch(value):
+        return True
+    raise ValidationError("Phone number is not valid.")
+
+
+def validate_postal_code(value: str) -> bool:
+    """Validate that a string represents a postal code.
+
+    Args:
+        value: The postal code string to validate.
+
+    Returns:
+        bool: ``True`` if the value matches common postal code patterns.
+
+    Raises:
+        ValidationError: If ``value`` is not a valid postal code.
+    """
+
+    pattern = re.compile(r"^[A-Za-z0-9][A-Za-z0-9\s\-]{2,10}$")
+    if pattern.fullmatch(value):
+        return True
+    raise ValidationError("Postal code is not valid.")
+
+
 def wrap_validator(validator: Callable[[str], bool | VE], error_message: str = "Not a valid value.") -> Callable[[str], None]:
     """Wrap a Marshmallow validator to raise :class:`ValidationError` on failure.
 
@@ -214,6 +253,8 @@ def validate_by_type(validator_type: str) -> Callable[[str], None] | None:
         "sha384": wrap_validator(validators.sha384, "SHA384 hash is not valid."),
         "sha512": wrap_validator(validators.sha512, "SHA512 hash is not valid."),
         "currency": wrap_validator(validators.currency, "Currency code is not valid."),
+        "phone": validate_phone_number,
+        "postal_code": validate_postal_code,
         "date": lambda value: validate_date(value, formats=["%Y-%m-%d", "%d-%m-%Y", "%m/%d/%Y"]),
         "datetime": lambda value: validate_datetime(
             value,

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -9,6 +9,8 @@ from flarchitect.schemas.validators import (
     validate_date,
     validate_datetime,
     validate_decimal,
+    validate_phone_number,
+    validate_postal_code,
     validate_time,
 )
 
@@ -21,6 +23,8 @@ from flarchitect.schemas.validators import (
         (validate_time, "23:59:59"),
         (validate_decimal, "10.5"),
         (validate_boolean, "true"),
+        (validate_phone_number, "+1 650-555-1234"),
+        (validate_postal_code, "12345"),
     ],
 )
 def test_custom_validators_success(validator, value):
@@ -36,6 +40,8 @@ def test_custom_validators_success(validator, value):
         (validate_time, "24:00:00"),
         (validate_decimal, "abc"),
         (validate_boolean, "maybe"),
+        (validate_phone_number, "abc"),
+        (validate_postal_code, "!!"),
     ],
 )
 def test_custom_validators_failure(validator, value):
@@ -76,6 +82,8 @@ def test_custom_validators_failure(validator, value):
         ("cron", "* * * * *", "bad cron"),
         ("base64", "aGVsbG8=", "invalid"),
         ("currency", "USD", "XXX"),
+        ("phone", "+1 650-555-1234", "not-phone"),
+        ("postal_code", "12345", "!!!"),
         ("date", "2024-01-01", "20240101"),
         ("datetime", "2024-01-01 12:00:00", "2024/01/01 12:00:00"),
         ("time", "23:59:59", "24:00:00"),


### PR DESCRIPTION
## Summary
- add phone and postal code validators
- automatically apply phone and postal code validation from column names or format metadata
- document new validation formats and test coverage

## Testing
- `ruff format .`
- `ruff check --fix .`
- `pytest tests/test_validators.py`


------
https://chatgpt.com/codex/tasks/task_e_689cd407a6848322b4acb62ebb245906