### PR TITLE
docs: add getting started sample and advanced demos

### DIFF
--- a/demo/advanced_features/app.py
+++ b/demo/advanced_features/app.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from flarchitect import Architect
+
+
+class BaseModel(DeclarativeBase):
+    """Base model with timestamp and soft delete columns."""
+
+    created: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
+    updated: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
+    deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    def get_session(*args: Any, **kwargs: Any):
+        """Return the current database session."""
+
+        return db.session
+
+
+db = SQLAlchemy(model_class=BaseModel)
+
+
+class Author(db.Model):
+    """Author of one or more books."""
+
+    __tablename__ = "author"
+
+    class Meta:
+        tag = "Author"
+        tag_group = "People"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(80))
+    books: Mapped[list[Book]] = relationship(back_populates="author")
+
+
+class Book(db.Model):
+    """Book written by an author."""
+
+    __tablename__ = "book"
+
+    class Meta:
+        tag = "Book"
+        tag_group = "Content"
+        allow_nested_writes = True
+        add_callback = staticmethod(lambda obj, model: _add_callback(obj))
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String(120))
+    author_id: Mapped[int] = mapped_column(ForeignKey("author.id"))
+    author: Mapped[Author] = relationship(back_populates="books")
+
+
+def _add_callback(obj: Book) -> Book:
+    """Ensure book titles are capitalised before saving."""
+
+    obj.title = obj.title.title()
+    return obj
+
+
+def return_callback(model: type[BaseModel], output: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    """Attach a debug flag to every response.
+
+    Args:
+        model: Model class being processed.
+        output: Response payload.
+
+    Returns:
+        Modified response dictionary.
+    """
+
+    output["debug"] = True
+    return {"output": output}
+
+
+def create_app() -> Flask:
+    """Build the Flask application and initialise flarchitect.
+
+    Returns:
+        Configured Flask application.
+    """
+
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        API_TITLE="Advanced API",
+        API_VERSION="1.0",
+        API_BASE_MODEL=db.Model,
+        API_ALLOW_NESTED_WRITES=True,
+        API_SOFT_DELETE=True,
+        API_SOFT_DELETE_ATTRIBUTE="deleted",
+        API_SOFT_DELETE_VALUES=(False, True),
+        API_RETURN_CALLBACK=return_callback,
+    )
+
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        Architect(app)
+
+    return app
+
+
+if __name__ == "__main__":
+    create_app().run(debug=True)

--- a/docs/source/advanced_demo.rst
+++ b/docs/source/advanced_demo.rst
@@ -1,0 +1,27 @@
+Advanced Demo
+=============
+
+This annotated example combines soft deletes, nested writes and custom callbacks.
+The code lives in ``demo/advanced_features/app.py``.
+
+.. literalinclude:: ../../demo/advanced_features/app.py
+   :language: python
+   :linenos:
+
+Key points
+----------
+
+* **Soft deletes** are enabled via ``API_SOFT_DELETE`` and the ``deleted`` column on ``BaseModel``.
+* **Nested writes** allow creating related objects in one request. ``Book.Meta.allow_nested_writes`` turns it on for books.
+* **Custom callbacks** modify behaviour: ``return_callback`` injects a ``debug`` flag into every response and ``Book.Meta.add_callback`` title-cases book names before saving.
+
+Run the demo
+------------
+
+.. code-block:: bash
+
+   python demo/advanced_features/app.py
+   curl -X POST http://localhost:5000/api/book \
+        -H "Content-Type: application/json" \
+        -d '{"title": "my book", "author": {"name": "Alice"}}'
+   curl http://localhost:5000/api/book?include_deleted=true

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,0 +1,17 @@
+Getting Started Sample Project
+==============================
+
+A minimal application that exposes an ``Author`` model through a generated REST API.
+The project lives in ``demo/quickstart/load.py``.
+
+.. literalinclude:: ../../demo/quickstart/load.py
+   :language: python
+   :linenos:
+
+Run the demo
+------------
+
+.. code-block:: bash
+
+   python demo/quickstart/load.py
+   curl http://localhost:5000/api/author

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,7 @@ flarchitect
 
    installation
    quickstart
+   getting_started
    models
    validation
    authentication
@@ -15,6 +16,7 @@ flarchitect
    configuration
    advanced_configuration
    soft_delete
+   advanced_demo
    openapi
    faq
    genindex


### PR DESCRIPTION
## Summary
- document a minimal getting started project
- add advanced demo showcasing soft deletes, nested writes and callbacks
- link new docs from the index

## Testing
- `ruff check demo/advanced_features/app.py`
- `pytest` *(fails: cannot import name 'Architect' from 'flarchitect')*

------
https://chatgpt.com/codex/tasks/task_e_689cd86f0f0c8322a9b37338c46a2827