### PR TITLE
fix: add custom response wrapper

### DIFF
--- a/flarchitect/utils/responses.py
+++ b/flarchitect/utils/responses.py
@@ -1,3 +1,12 @@
+"""Utilities for serialising and wrapping API responses.
+
+This module provides helper types and functions used to construct consistent
+responses throughout the project.  The :class:`CustomResponse` data class allows
+endpoints to supply additional pagination metadata that
+``create_response`` understands.
+"""
+
+from dataclasses import dataclass
 from typing import Any
 
 from marshmallow import Schema, ValidationError
@@ -6,6 +15,23 @@ from flarchitect.schemas.bases import AutoSchema
 from flarchitect.schemas.utils import dump_schema_if_exists
 from flarchitect.utils.core_utils import get_count
 from flarchitect.utils.general import HTTP_INTERNAL_SERVER_ERROR
+
+
+@dataclass
+class CustomResponse:
+    """Container for API response data and pagination metadata.
+
+    Attributes:
+        value: The primary payload to return to the client.
+        next_url: Link to the next page of results, if available.
+        previous_url: Link to the previous page of results, if available.
+        count: Total number of objects available.
+    """
+
+    value: Any
+    next_url: str | None = None
+    previous_url: str | None = None
+    count: int | None = None
 
 
 def serialize_output_with_mallow(output_schema: type[Schema], data: Any) -> dict[str, Any] | tuple[dict[str, Any], int]:

--- a/tests/test_response_helpers.py
+++ b/tests/test_response_helpers.py
@@ -3,6 +3,7 @@
 from flask import Flask
 
 from flarchitect.utils.response_helpers import create_response
+from flarchitect.utils.responses import CustomResponse
 
 
 def _make_app() -> Flask:
@@ -45,3 +46,16 @@ def test_create_response_sets_errors_for_bad_status() -> None:
         assert data["value"] is None
         assert data["status_code"] == 400
         assert resp.status_code == 400
+
+
+def test_create_response_handles_custom_response() -> None:
+    """CustomResponse instances expose pagination metadata."""
+    app = _make_app()
+    custom = CustomResponse(value={"msg": "ok"}, next_url="/next", previous_url="/prev", count=1)
+    with app.test_request_context():
+        resp = create_response(result=custom)
+        data = resp.get_json()
+        assert data["value"] == {"msg": "ok"}
+        assert data["next_url"] == "/next"
+        assert data["previous_url"] == "/prev"
+        assert data["total_count"] == 1


### PR DESCRIPTION
## Summary
- add `CustomResponse` dataclass for richer API responses
- test `create_response` handling of `CustomResponse`
- fix soft-delete tests by providing missing response wrapper

## Testing
- `pytest tests/test_response_helpers.py -vv`
- `pytest tests/test_soft_delete.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689cd919c3808322b26f8c573cdc3efd