### PR TITLE
Add edge case tests

### DIFF
--- a/tests/test_nested_writes.py
+++ b/tests/test_nested_writes.py
@@ -116,3 +116,28 @@ def test_post_book_with_author_and_publisher(client):
     }
     resp = client.post("/api/books", json=data)
     assert resp.status_code == 200
+
+
+def test_nested_write_missing_required_field(client):
+    """A nested write missing required fields should return an error response."""
+
+    data = {
+        "first_name": "Bad",
+        "last_name": "Author",
+        "biography": "Bio",
+        "date_of_birth": "1990-01-01",
+        "nationality": "US",
+        "books": [
+            {
+                # missing title field
+                "isbn": "55555",
+                "publication_date": "2024-01-01",
+                "publisher_id": 1,
+                "author_id": 0,
+            }
+        ],
+    }
+    resp = client.post("/api/authors", json=data)
+    body = resp.get_json()
+    assert resp.status_code == 400
+    assert body["errors"]["error"]["books"]["0"]["title"][0] == "Missing data for required field."

--- a/tests/test_rate_limit_services.py
+++ b/tests/test_rate_limit_services.py
@@ -23,6 +23,10 @@ class TestRateLimitServices:
             "flarchitect.utils.general.get_config_or_model_meta",
             lambda key, default=None, model=None: "redis://127.0.0.1:6379",
         )
+        monkeypatch.setattr(
+            "flarchitect.utils.general.check_rate_prerequisites",
+            lambda service: None,
+        )
 
         assert check_rate_services() == "redis://127.0.0.1:6379"
 
@@ -57,3 +61,13 @@ class TestRateLimitServices:
         monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
         with pytest.raises(ImportError):
             check_rate_prerequisites("Redis")
+
+    def test_invalid_storage_uri_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Unsupported URI schemes raise a ``ValueError``."""
+
+        monkeypatch.setattr(
+            "flarchitect.utils.general.get_config_or_model_meta",
+            lambda key, default=None, model=None: "invalid://localhost",
+        )
+        with pytest.raises(ValueError):
+            check_rate_services()


### PR DESCRIPTION
## Summary
- validate rate limit storage URIs and raise for unsupported schemes
- test refresh token expiration handling
- test invalid rate limit backend URIs
- test nested writes with missing required fields

## Testing
- `ruff check tests/test_authentication.py tests/test_rate_limit_services.py tests/test_nested_writes.py flarchitect/utils/general.py`
- `pytest tests/test_authentication.py::test_expired_refresh_token -q`
- `pytest tests/test_rate_limit_services.py -q`
- `pytest tests/test_nested_writes.py::test_nested_write_missing_required_field -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd8669cd48322b61c6004ab22ea3f