### PR TITLE
Expose configurable OpenAPI spec route

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,19 +51,16 @@ config. Either way you can serve the raw specification to integrate with
 tooling such as Postman:
 
 ```python
-from flask import Flask, Response, jsonify
+from flask import Flask
 from flarchitect import Architect
 
 app = Flask(__name__)
-architect = Architect(app)
-
-@app.get("/openapi.json")
-def openapi() -> Response:
-    return jsonify(architect.api_spec.to_dict())
+architect = Architect(app)  # OpenAPI served at /openapi.json
 ```
 
-See the [OpenAPI docs](docs/source/openapi.rst) for exporting or customising
-the document.
+The specification endpoint can be customised with ``API_SPEC_ROUTE``. See the
+[OpenAPI docs](docs/source/openapi.rst) for exporting or customising the
+document.
 
 Read about hiding and restoring records with the [soft delete guide](docs/source/soft_delete.rst).
 

--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -14,6 +14,14 @@
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - URL path where documentation is served. Useful for mounting docs under a custom route such as ``/redoc``. Accepts any valid path string. Example: `tests/test_flask_config.py <https://github.com/arched-dev/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``API_SPEC_ROUTE``
+
+          :bdg:`default:` ``/openapi.json``
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Path where the raw OpenAPI document is served. Override to change the
+          URL exposed by the automatic endpoint.
     * - ``API_TITLE``
 
           :bdg:`default:` ``None``

--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -18,20 +18,8 @@ added later are included the next time the application boots.
 Accessing the spec
 ------------------
 
-The generated schema is served at ``/openapi.json``.  You can expose it
-manually if you prefer:
-
-.. code-block:: python
-
-    from flask import Flask, Response, jsonify
-    from flarchitect import Architect
-
-    app = Flask(__name__)
-    architect = Architect(app)
-
-    @app.get("/openapi.json")
-    def openapi() -> Response:
-        return jsonify(architect.api_spec.to_dict())
+The generated schema is automatically served at ``/openapi.json``. Override
+the URL with ``API_SPEC_ROUTE`` if you need to mount the document elsewhere.
 
 Exporting to a file
 -------------------

--- a/tests/test_spec_route.py
+++ b/tests/test_spec_route.py
@@ -1,0 +1,21 @@
+from demo.basic_factory.basic_factory import create_app
+
+
+def test_default_spec_route():
+    """The OpenAPI spec is served at the default path."""
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/openapi.json")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert isinstance(data, dict)
+    assert data.get("openapi")
+
+
+def test_custom_spec_route():
+    """The spec route can be overridden via configuration."""
+    app = create_app({"API_SPEC_ROUTE": "/spec.json"})
+    client = app.test_client()
+    resp = client.get("/spec.json")
+    assert resp.status_code == 200
+    assert resp.get_json().get("openapi")


### PR DESCRIPTION
## Summary
- serve OpenAPI spec at a configurable endpoint (`API_SPEC_ROUTE`)
- document spec route and add tests

## Testing
- `ruff check --fix flarchitect/core/architect.py tests/test_spec_route.py`
- `ruff format flarchitect/core/architect.py tests/test_spec_route.py`
- `pytest tests/test_spec_route.py`
- ⚠️ `pytest` (import error: cannot import name 'Architect')

------
https://chatgpt.com/codex/tasks/task_e_689cda2573ec832281cbae3aaaba09b6