### PR TITLE
Add JWT auth negative test cases

### DIFF
--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -4,7 +4,7 @@ import base64
 from collections.abc import Generator
 
 import pytest
-from flask import Flask, request
+from flask import Flask, Response, request
 from flask.testing import FlaskClient
 from flask_sqlalchemy import SQLAlchemy
 from marshmallow import Schema, fields
@@ -235,6 +235,16 @@ def client_custom() -> Generator[FlaskClient, None, None]:
         yield app.test_client()
 
 
+def assert_unauthorized(resp: Response) -> None:
+    """Assert unauthorized response and cleared user context.
+
+    Args:
+        resp (Response): Flask response object to verify.
+    """
+    assert resp.status_code == 401
+    assert get_current_user() is None
+
+
 def test_basic_success_and_failure(client_basic: FlaskClient) -> None:
     """Test basic authentication and ensure user context resets."""
     assert get_current_user() is None
@@ -313,6 +323,38 @@ def test_jwt_success_and_failure(client_jwt: tuple[FlaskClient, str, str]) -> No
     with pytest.raises(CustomHTTPException):
         refresh_access_token(refresh_token)
     assert get_current_user() is None
+
+
+def test_jwt_no_authorization_header(
+    client_jwt: tuple[FlaskClient, str, str],
+) -> None:
+    """Ensure JWT auth fails without an Authorization header."""
+    client, _, _ = client_jwt
+    assert get_current_user() is None
+    resp = client.get("/jwt")
+    assert_unauthorized(resp)
+
+
+def test_jwt_missing_bearer_prefix(
+    client_jwt: tuple[FlaskClient, str, str],
+) -> None:
+    """Reject tokens lacking the Bearer prefix."""
+    client, access_token, _ = client_jwt
+    assert get_current_user() is None
+    resp = client.get("/jwt", headers={"Authorization": access_token})
+    assert_unauthorized(resp)
+
+
+def test_jwt_expired_token(client_jwt: tuple[FlaskClient, str, str]) -> None:
+    """Reject expired JWT access tokens."""
+    client, _, _ = client_jwt
+    with client.application.app_context():
+        user = User.query.filter_by(username="carol").first()
+        assert user is not None
+        expired_token = generate_access_token(user, expires_in_minutes=-1)
+    assert get_current_user() is None
+    resp = client.get("/jwt", headers={"Authorization": f"Bearer {expired_token}"})
+    assert_unauthorized(resp)
 
 
 def test_custom_success_and_failure(client_custom: FlaskClient) -> None:


### PR DESCRIPTION
## Summary
- test helper asserts 401 responses keep user context empty
- add JWT auth tests for missing header, missing Bearer prefix and expired token

## Testing
- `pytest tests/test_authentication.py` *(fails: cannot import name 'CustomResponse')*
- `pytest tests/test_authentication.py::test_jwt_no_authorization_header tests/test_authentication.py::test_jwt_missing_bearer_prefix tests/test_authentication.py::test_jwt_expired_token -q`


------
https://chatgpt.com/codex/tasks/task_e_689cda2747d8832288b8f5b8c7c4d6ce