### PR TITLE
Add optional CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQ
 - **Highly configurable** – tweak behaviour globally via Flask config or per model with `Meta` attributes.
 - **Field validation** – built-in validators for emails, URLs, IPs and more.
 - **Nested writes** – opt-in support for sending related objects in POST/PUT payloads. Enable with `API_ALLOW_NESTED_WRITES = True` and let `AutoSchema` deserialize them automatically.
+- **CORS support** – enable cross-origin requests with `API_ENABLE_CORS`. See the [advanced configuration guide](docs/source/advanced_configuration.rst#cors) for an example.
 
 ## Installation
 

--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -70,6 +70,23 @@ options, mirroring the format used by `Flask-CORS <https://flask-cors.readthedoc
             r"/api/*": {"origins": "*"}
         }
 
+Example
+^^^^^^^
+
+The following snippet enables CORS for all API routes::
+
+    from flask import Flask
+    from flarchitect import Architect
+
+    app = Flask(__name__)
+    app.config["API_ENABLE_CORS"] = True
+    app.config["CORS_RESOURCES"] = {r"/api/*": {"origins": "*"}}
+
+    architect = Architect(app)
+
+    if __name__ == "__main__":
+        app.run()
+
 See the :doc:`configuration <configuration>` page for the full list of
 available CORS settings.
 

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -100,6 +100,14 @@ class Architect(AttributeInitializerMixin):
         logger.verbosity_level = self.get_config("API_VERBOSITY_LEVEL", 0)
         self.api_spec = None
 
+        if self.get_config("API_ENABLE_CORS", False):
+            try:
+                from flask_cors import CORS
+            except ModuleNotFoundError as exc:
+                raise RuntimeError("flask-cors is required when API_ENABLE_CORS is True") from exc
+            # Apply CORS rules from the configuration when enabled.
+            CORS(app, resources=app.config.get("CORS_RESOURCES", {}))
+
         if self.get_config("FULL_AUTO", True):
             self.init_api(app=app, **kwargs)
         if get_config_or_model_meta("API_CREATE_DOCS", default=True):

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,55 @@
+import pytest
+from flask import Flask
+
+from flarchitect.core.architect import Architect
+
+
+def create_app(config: dict | None = None) -> Flask:
+    app = Flask(__name__)
+    if config:
+        app.config.update(config)
+    with app.app_context():
+        Architect(app)
+
+    @app.get("/ping")
+    def ping() -> str:
+        return "pong"
+
+    return app
+
+
+@pytest.fixture
+def client_with_cors() -> Flask.test_client:  # type: ignore[name-defined]
+    app = create_app(
+        {
+            "API_ENABLE_CORS": True,
+            "CORS_RESOURCES": {r"/ping": {"origins": "*"}},
+            "FULL_AUTO": False,
+            "API_CREATE_DOCS": False,
+        }
+    )
+    return app.test_client()
+
+
+@pytest.fixture
+def client_without_cors() -> Flask.test_client:  # type: ignore[name-defined]
+    app = create_app(
+        {
+            "API_ENABLE_CORS": False,
+            "FULL_AUTO": False,
+            "API_CREATE_DOCS": False,
+        }
+    )
+    return app.test_client()
+
+
+def test_cors_header_present(client_with_cors) -> None:
+    response = client_with_cors.get("/ping", headers={"Origin": "http://example.com"})
+    assert response.status_code == 200
+    assert response.headers.get("Access-Control-Allow-Origin") is not None
+
+
+def test_cors_header_absent(client_without_cors) -> None:
+    response = client_without_cors.get("/ping", headers={"Origin": "http://example.com"})
+    assert response.status_code == 200
+    assert "Access-Control-Allow-Origin" not in response.headers


### PR DESCRIPTION
## Summary
- enable optional CORS initialisation when `API_ENABLE_CORS` is true
- document CORS configuration and link from README
- test CORS header presence when enabled

## Testing
- `ruff check --fix flarchitect/core/architect.py tests/test_cors.py`
- `pytest tests/test_cors.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689cda20c2e48322b2f55d26c137d0f9