### PR TITLE
feat: add client generation CLI

### DIFF
--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -45,6 +45,21 @@ To generate a static JSON document for deployment or tooling:
     with open("openapi.json", "w") as fh:
         json.dump(architect.api_spec.to_dict(), fh, indent=2)
 
+CLI helper
+----------
+
+The ``flarchitect`` command-line tool can export the specification and run `openapi-generator <https://openapi-generator.tech/>`_ to scaffold a client:
+
+.. code-block:: bash
+
+    $ FLASK_APP=app.py flarchitect client --lang typescript ./client
+
+This writes ``openapi.json`` to the output directory and, when the ``openapi-generator`` executable is available, generates a client library. If the tool is missing, the command still creates ``openapi.json`` and prints a warning. Install it with:
+
+.. code-block:: bash
+
+    $ npm install -g @openapitools/openapi-generator-cli
+
 Customising the document
 ------------------------
 

--- a/flarchitect/cli.py
+++ b/flarchitect/cli.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from flask import Flask
+
+
+def _load_app() -> Flask:
+    """Load a Flask application from ``FLASK_APP``.
+
+    Returns:
+        Flask: The application instance exported by the configured module.
+
+    Raises:
+        RuntimeError: If ``FLASK_APP`` is unset or the application cannot be loaded.
+    """
+    flask_app = os.environ.get("FLASK_APP")
+    if not flask_app:
+        raise RuntimeError("FLASK_APP environment variable is not set.")
+    module_name, _, app_name = flask_app.partition(":")
+    if not app_name:
+        app_name = "app"
+    module = importlib.import_module(module_name)
+    try:
+        app = getattr(module, app_name)
+    except AttributeError as exc:  # pragma: no cover - defensive branch
+        msg = f"{flask_app} does not export a Flask application."
+        raise RuntimeError(msg) from exc
+    return app
+
+
+def _export_openapi(app: Flask, output_dir: Path) -> Path:
+    """Export the application's OpenAPI specification to ``openapi.json``.
+
+    Args:
+        app: The Flask application whose spec will be exported.
+        output_dir: Directory to write ``openapi.json`` into.
+
+    Returns:
+        Path: The path to the generated ``openapi.json`` file.
+    """
+    spec = app.extensions["flarchitect"].api_spec.to_dict()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    spec_path = output_dir / "openapi.json"
+    with spec_path.open("w", encoding="utf-8") as fh:
+        json.dump(spec, fh, indent=2)
+    return spec_path
+
+
+def _generate_client(spec_path: Path, lang: str, output_dir: Path) -> None:
+    """Generate a client library using ``openapi-generator`` if available.
+
+    Args:
+        spec_path: Path to the ``openapi.json`` specification file.
+        lang: Target language for the generated client.
+        output_dir: Directory to output the client code.
+    """
+    generator = shutil.which("openapi-generator") or shutil.which("openapi-generator-cli")
+    if not generator:
+        print("openapi-generator not installed; skipping client generation.", file=sys.stderr)
+        return
+    subprocess.run(
+        [generator, "generate", "-i", str(spec_path), "-g", lang, "-o", str(output_dir)],
+        check=True,
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Entry point for the ``flarchitect`` command-line interface.
+
+    Args:
+        argv: Optional list of command-line arguments. Defaults to ``sys.argv``.
+    """
+    parser = argparse.ArgumentParser(prog="flarchitect")
+    subparsers = parser.add_subparsers(dest="command")
+
+    client_parser = subparsers.add_parser("client", help="Generate an API client from the OpenAPI spec.")
+    client_parser.add_argument("--lang", default="typescript", help="Target language for the client.")
+    client_parser.add_argument("output_dir", help="Directory to output the client code.")
+
+    args = parser.parse_args(argv)
+    if args.command == "client":
+        app = _load_app()
+        spec_path = _export_openapi(app, Path(args.output_dir))
+        _generate_client(spec_path, args.lang, Path(args.output_dir))
+    else:  # pragma: no cover - fallback for missing command
+        parser.print_help()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ dev = [
   "ruff",
   "isort"
 ]
+[project.scripts]
+flarchitect = "flarchitect.cli:main"
+
 [tool.ruff]
 exclude = ["./tests", ".bzr", ".direnv", ".eggs", ".git", "./frontend/*", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "dist", "node_modules", ".venv"]
 fix = true

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,66 @@
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Load CLI module without importing the full package
+CLI_PATH = Path(__file__).resolve().parents[1] / "flarchitect" / "cli.py"
+spec = importlib.util.spec_from_file_location("cli", CLI_PATH)
+cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cli)
+
+
+def _write_app(tmp_path: Path) -> None:
+    module_path = tmp_path / "appmodule.py"
+    module_path.write_text(
+        "from flask import Flask\n"
+        "app = Flask(__name__)\n"
+        "class DummySpec:\n"
+        "    def to_dict(self):\n"
+        "        return {'openapi': '3.0.2'}\n"
+        "class DummyExt:\n"
+        "    api_spec = DummySpec()\n"
+        "app.extensions = {'flarchitect': DummyExt()}\n"
+    )
+    sys.path.insert(0, str(tmp_path))
+
+
+@pytest.fixture
+def app_env(tmp_path, monkeypatch):
+    _write_app(tmp_path)
+    monkeypatch.setenv("FLASK_APP", "appmodule:app")
+    yield tmp_path
+    sys.path.remove(str(tmp_path))
+
+
+def test_client_generates_openapi_and_invokes_generator(app_env, monkeypatch):
+    output_dir = app_env / "client"
+    run_mock = mock.Mock()
+    monkeypatch.setattr(cli, "subprocess", mock.Mock(run=run_mock))
+    monkeypatch.setattr(cli.shutil, "which", lambda x: "/usr/bin/openapi-generator")
+
+    cli.main(["client", "--lang", "typescript", str(output_dir)])
+
+    spec_path = output_dir / "openapi.json"
+    assert spec_path.exists()
+    data = json.loads(spec_path.read_text())
+    assert data.get("openapi")
+    run_mock.assert_called_once()
+
+
+def test_client_handles_missing_generator(app_env, monkeypatch, capsys):
+    output_dir = app_env / "client"
+    monkeypatch.setattr(cli.shutil, "which", lambda x: None)
+    run_mock = mock.Mock()
+    monkeypatch.setattr(cli.subprocess, "run", run_mock)
+
+    cli.main(["client", str(output_dir)])
+
+    spec_path = output_dir / "openapi.json"
+    assert spec_path.exists()
+    assert not run_mock.called
+    captured = capsys.readouterr()
+    assert "not installed" in captured.err


### PR DESCRIPTION
## Summary
- add `flarchitect client` CLI to export OpenAPI spec and optionally run `openapi-generator`
- document client generation and dependency handling
- test CLI behaviour with mocked generator

## Testing
- `ruff check --fix flarchitect/cli.py tests/test_cli.py`
- `ruff format flarchitect/cli.py tests/test_cli.py pyproject.toml`
- `pytest` *(fails: ModuleNotFoundError and other errors)*
- `pytest tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_689cda3322a88322803c1b618e914105