### PR TITLE
Add role-based access decorator and documentation support

### DIFF
--- a/flarchitect/authentication/__init__.py
+++ b/flarchitect/authentication/__init__.py
@@ -1,0 +1,5 @@
+"""Authentication helpers and decorators."""
+
+from .roles import roles_required
+
+__all__ = ["roles_required"]

--- a/flarchitect/authentication/roles.py
+++ b/flarchitect/authentication/roles.py
@@ -1,0 +1,46 @@
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar, cast
+
+from flarchitect.authentication.user import current_user
+from flarchitect.exceptions import CustomHTTPException
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def roles_required(*roles: str) -> Callable[[F], F]:
+    """Restrict access to users possessing specific roles.
+
+    Args:
+        *roles: Variable length argument list of role names required to access
+            the decorated endpoint.
+
+    Returns:
+        Callable[[F], F]: A decorator enforcing role-based access control.
+
+    Raises:
+        CustomHTTPException: Raised with status code ``403`` when the current
+            user lacks any of the required roles or no user is authenticated.
+    """
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            user_roles = getattr(current_user, "roles", None)
+            if user_roles is None:
+                raise CustomHTTPException(status_code=403, reason="Roles required")
+
+            if roles and not set(roles).issubset(set(user_roles)):
+                raise CustomHTTPException(status_code=403, reason="Roles required")
+
+            return func(*args, **kwargs)
+
+        if not hasattr(wrapper, "_decorators"):
+            wrapper._decorators = []  # type: ignore[attr-defined]
+        decorator.__name__ = "roles_required"
+        decorator._args = roles  # type: ignore[attr-defined]
+        wrapper._decorators.append(decorator)  # type: ignore[attr-defined]
+
+        return cast(F, wrapper)
+
+    return decorator

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -13,6 +13,7 @@ from flask_limiter.util import get_remote_address
 from marshmallow import Schema
 from sqlalchemy.orm import DeclarativeBase
 
+from flarchitect.authentication import roles_required
 from flarchitect.authentication.jwt import get_user_from_token
 from flarchitect.authentication.user import set_current_user
 from flarchitect.core.routes import RouteCreator, find_rule_by_function
@@ -401,26 +402,32 @@ class Architect(AttributeInitializerMixin):
         model: DeclarativeBase | None = None,
         group_tag: str | None = None,
         many: bool | None = False,
+        roles: bool | list[str] | tuple[str, ...] | None = False,
         **kwargs,
     ) -> Callable:
-        """Decorate an endpoint with schema and OpenAPI metadata.
+        """Decorate an endpoint with schema, role, and OpenAPI metadata.
 
         Args:
-            output_schema (Optional[Type[Schema]], optional):
-                Output schema. Defaults to ``None``.
-            input_schema (Optional[Type[Schema]], optional):
-                Input schema. Defaults to ``None``.
-            model (Optional[DeclarativeBase], optional):
-                Database model. Defaults to ``None``.
-            group_tag (Optional[str], optional):
-                Group name. Defaults to ``None``.
-            many (Optional[Bool], optional):
-                Indicates if multiple items are returned. Defaults to ``False``.
-            kwargs (dict): Additional keyword arguments.
+            output_schema: Output schema. Defaults to ``None``.
+            input_schema: Input schema. Defaults to ``None``.
+            model: Database model. Defaults to ``None``.
+            group_tag: Group name. Defaults to ``None``.
+            many: Indicates if multiple items are returned. Defaults to ``False``.
+            roles: Roles required to access the endpoint. When truthy and
+                authentication is enabled, the :func:`roles_required` decorator
+                is applied. Defaults to ``False``.
+            kwargs: Additional keyword arguments.
 
         Returns:
             Callable: The decorated function.
         """
+
+        auth_flag = kwargs.get("auth")
+        roles_tuple: tuple[str, ...] = ()
+        if roles and roles is not True:
+            roles_tuple = (
+                tuple(roles) if isinstance(roles, list | tuple) else (str(roles),)
+            )
 
         def decorator(f: Callable) -> Callable:
             @wraps(f)
@@ -429,7 +436,7 @@ class Architect(AttributeInitializerMixin):
                     model=model,
                     output_schema=output_schema,
                     input_schema=input_schema,
-                    auth_flag=kwargs.get("auth"),
+                    auth_flag=auth_flag,
                 )
 
                 f_decorated = self._apply_schemas(f, output_schema, input_schema, bool(many))
@@ -440,7 +447,19 @@ class Architect(AttributeInitializerMixin):
                     input_schema=input_schema,
                 )
 
+                if roles and auth_flag is not False:
+                    f_decorated = roles_required(*roles_tuple)(f_decorated)
+
                 return f_decorated(*_args, **_kwargs)
+
+            if roles and auth_flag is not False:
+                def _marker() -> None:
+                    """Marker function for roles documentation."""
+
+                _marker.__name__ = "roles_required"
+                _marker._args = roles_tuple  # type: ignore[attr-defined]
+                wrapped._decorators = getattr(wrapped, "_decorators", [])
+                wrapped._decorators.append(_marker)  # type: ignore[attr-defined]
 
             # Store route information for OpenAPI documentation
             route_info = {

--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -962,12 +962,12 @@ def handle_authorization(f: Callable, spec_template: dict[str, Any]):
     Returns:
         None
     """
-    roles_required = None
+    required_roles = None
 
     if hasattr(f, "_decorators"):
         for decorator in f._decorators:
-            if decorator.__name__ == "auth_required":
-                roles_required = decorator._args
+            if decorator.__name__ == "roles_required":
+                required_roles = decorator._args
                 spec_template["parameters"].append(
                     {
                         "name": "Authorization",
@@ -979,8 +979,8 @@ def handle_authorization(f: Callable, spec_template: dict[str, Any]):
                 )
                 break
 
-    if roles_required:
-        roles_desc = ", ".join(roles_required)
+    if required_roles:
+        roles_desc = ", ".join(required_roles)
         spec_template["responses"]["401"]["description"] += f" Roles required: {roles_desc}."
 
 

--- a/tests/test_roles_required.py
+++ b/tests/test_roles_required.py
@@ -1,0 +1,91 @@
+"""Tests for the roles_required decorator and schema integration."""
+
+from collections.abc import Generator
+from types import SimpleNamespace
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+from marshmallow import Schema, fields
+
+from flarchitect import Architect
+from flarchitect.authentication import roles_required
+from flarchitect.authentication.user import set_current_user
+from flarchitect.exceptions import CustomHTTPException
+from flarchitect.specs.utils import handle_authorization
+from flarchitect.utils.response_helpers import create_response
+
+
+def test_roles_required_direct() -> None:
+    """The decorator blocks access when roles are missing."""
+
+    @roles_required("admin")
+    def sample() -> str:
+        return "ok"
+
+    set_current_user(SimpleNamespace(roles=["admin"]))
+    assert sample() == "ok"
+
+    set_current_user(SimpleNamespace(roles=["user"]))
+    with pytest.raises(CustomHTTPException):
+        sample()
+
+
+@pytest.fixture()
+def client_roles() -> Generator[FlaskClient, None, None]:
+    """Create a Flask client with a route enforcing roles."""
+
+    app = Flask(__name__)
+    app.config.update(FULL_AUTO=False, API_CREATE_DOCS=False)
+
+    with app.app_context():
+        architect = Architect(app=app)
+        holder = SimpleNamespace(user=None)
+
+        class PingSchema(Schema):
+            status = fields.Str()
+
+        @app.before_request
+        def load_user() -> None:
+            set_current_user(holder.user)
+
+        @app.errorhandler(CustomHTTPException)
+        def handle_custom(exc: CustomHTTPException):
+            return create_response(status=exc.status_code, errors={"error": exc.error, "reason": exc.reason})
+
+        @app.route("/protected")
+        @architect.schema_constructor(output_schema=PingSchema, roles=("admin",))
+        def protected() -> dict[str, str]:
+            return {"status": "ok"}
+
+        client = app.test_client()
+        yield client, holder
+
+
+def test_schema_constructor_applies_roles(client_roles: tuple[FlaskClient, SimpleNamespace]) -> None:
+    """Access is restricted based on user roles when configured."""
+
+    client, holder = client_roles
+
+    holder.user = SimpleNamespace(roles=["admin"])
+    resp = client.get("/protected")
+    assert resp.status_code == 200
+
+    holder.user = SimpleNamespace(roles=["user"])
+    resp = client.get("/protected")
+    assert resp.status_code == 403
+
+
+def test_openapi_documents_roles() -> None:
+    """OpenAPI specification documents required roles."""
+
+    spec_template = {"parameters": [], "responses": {"401": {"description": ""}}}
+
+    @roles_required("admin", "editor")
+    def view() -> None:  # pragma: no cover - simple callable
+        pass
+
+    handle_authorization(view, spec_template)
+
+    assert any(param["name"] == "Authorization" for param in spec_template["parameters"])
+    assert "Roles required: admin, editor" in spec_template["responses"]["401"]["description"]


### PR DESCRIPTION
## Summary
- add `roles_required` decorator for role-based access control
- wire roles enforcement into `schema_constructor`
- document required roles in OpenAPI generation

## Testing
- `ruff check --fix flarchitect tests/test_roles_required.py`
- `pytest tests/test_roles_required.py`


------
https://chatgpt.com/codex/tasks/task_e_689cde4400e883229d406a9de05fd3a5