### PR TITLE
Add optional Flask-Caching support

### DIFF
--- a/flarchitect/core/routes.py
+++ b/flarchitect/core/routes.py
@@ -759,7 +759,17 @@ class RouteCreator(AttributeInitializerMixin):
             output_schema=kwargs.get("output_schema"),
         )
 
-        unique_route_function = self._create_unique_route_function(route_function, kwargs["url"], http_method, kwargs.get("many", False))
+        unique_route_function = self._create_unique_route_function(
+            route_function,
+            kwargs["url"],
+            http_method,
+            kwargs.get("many", False),
+        )
+
+        if http_method == "GET" and self.architect.cache:
+            timeout = self.architect.get_config("API_CACHE_TIMEOUT", 300)
+            unique_route_function = self.architect.cache.cached(timeout=timeout)(unique_route_function)
+
         kwargs["function"] = unique_route_function
 
         # Register the route with Flask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ dev = [
   "ruff",
   "isort"
 ]
+cache = [
+  "flask-caching>=2.1.0",
+]
 [tool.ruff]
 exclude = ["./tests", ".bzr", ".direnv", ".eggs", ".git", "./frontend/*", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "dist", "node_modules", ".venv"]
 fix = true

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,25 @@
+import time
+
+from demo.model_extension.model import create_app
+from demo.model_extension.model.extensions import db
+from demo.model_extension.model.models import Author
+
+
+def test_get_endpoint_cached_response():
+    app = create_app({"API_CACHE_TYPE": "SimpleCache", "API_CACHE_TIMEOUT": 1})
+    client = app.test_client()
+
+    first = client.get("/api/authors/1").get_json()["value"]["first_name"]
+
+    with app.app_context():
+        author = db.session.get(Author, 1)
+        author.first_name = "Cached"
+        db.session.commit()
+
+    second = client.get("/api/authors/1").get_json()["value"]["first_name"]
+    assert second == first
+
+    time.sleep(1.1)
+
+    third = client.get("/api/authors/1").get_json()["value"]["first_name"]
+    assert third == "Cached"


### PR DESCRIPTION
## Summary
- configure optional Flask-Caching via `API_CACHE_TYPE` and `API_CACHE_TIMEOUT`
- cache GET endpoints through `Architect` and `RouteCreator`
- add regression test ensuring cached responses respect timeout

## Testing
- `ruff check --fix flarchitect/core/architect.py flarchitect/core/routes.py tests/test_cache.py`
- `ruff format flarchitect/core/architect.py flarchitect/core/routes.py tests/test_cache.py`
- `pytest` *(fails: ImportError: cannot import name 'Architect' from 'flarchitect')*
- `pytest tests/test_cache.py tests/test_soft_delete.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689cde4f5b88832284ea81251c25b59e