### PR TITLE
docs: document API dump metadata options

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -51,6 +51,79 @@ storage URI:
 If no backend is available, the limiter falls back to in-memory storage
 with rate-limit headers enabled by default.
 
+Response metadata
+-----------------
+
+``flarchitect`` can attach additional metadata to every response. These
+keys let you toggle each field individually:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Key
+     - Default
+     - Effect
+   * - ``API_DUMP_HYBRID_PROPERTIES``
+     - ``True``
+     - Include SQLAlchemy hybrid properties in serialized output.
+   * - ``API_DUMP_DATETIME``
+     - ``True``
+     - Append the current UTC timestamp as ``datetime``.
+   * - ``API_DUMP_VERSION``
+     - ``True``
+     - Embed the API version string as ``api_version``.
+   * - ``API_DUMP_STATUS_CODE``
+     - ``True``
+     - Add the HTTP status code to the payload.
+   * - ``API_DUMP_RESPONSE_MS``
+     - ``True``
+     - Include elapsed processing time in milliseconds as ``response_ms``.
+   * - ``API_DUMP_TOTAL_COUNT``
+     - ``True``
+     - Provide a ``total_count`` field for collection endpoints.
+   * - ``API_DUMP_NULL_NEXT_URL``
+     - ``True``
+     - Show ``next_url`` with ``null`` when no further page exists.
+   * - ``API_DUMP_NULL_PREVIOUS_URL``
+     - ``True``
+     - Show ``previous_url`` with ``null`` when at the first page.
+   * - ``API_DUMP_NULL_ERRORS``
+     - ``True``
+     - Always include an ``errors`` field, defaulting to ``null``.
+
+Example
+^^^^^^^
+
+With metadata enabled (defaults)::
+
+    {
+        "data": [...],
+        "datetime": "2024-01-01T00:00:00Z",
+        "api_version": "0.0.0",
+        "status_code": 200,
+        "response_ms": 15,
+        "total_count": 1,
+        "next_url": null,
+        "previous_url": null,
+        "errors": null
+    }
+
+Disabling all metadata::
+
+    class Config:
+        API_DUMP_DATETIME = False
+        API_DUMP_VERSION = False
+        API_DUMP_STATUS_CODE = False
+        API_DUMP_RESPONSE_MS = False
+        API_DUMP_TOTAL_COUNT = False
+        API_DUMP_NULL_NEXT_URL = False
+        API_DUMP_NULL_PREVIOUS_URL = False
+        API_DUMP_NULL_ERRORS = False
+
+    {
+        "data": [...]
+    }
+
 CORS
 ----
 


### PR DESCRIPTION
## Summary
- document API_DUMP_* configuration keys for controlling response metadata
- illustrate response payload with metadata enabled vs disabled

## Testing
- `ruff check .`
- `ruff format docs/source/advanced_configuration.rst` *(fails: Failed to parse docs/source/advanced_configuration.rst)*
- `pytest` *(fails: ImportError: cannot import name 'Architect' from 'flarchitect')*

------
https://chatgpt.com/codex/tasks/task_e_689cdf7843a0832284ef53b8222c52dd