### PR TITLE
doc: explain cascade delete option

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -90,6 +90,25 @@ The following snippet enables CORS for all API routes::
 See the :doc:`configuration <configuration>` page for the full list of
 available CORS settings.
 
+Cascade deletes
+---------------
+
+By default, ``flarchitect`` blocks cascade deletions to protect related data.
+Enabling :data:`API_ALLOW_CASCADE_DELETE` allows a parent record and its
+children to be removed together.
+
+When enabled, clients must opt in using the ``cascade_delete=1`` query flag:
+
+.. code-block:: http
+
+   DELETE /api/authors/1?cascade_delete=1
+
+Omitting the flag triggers an error reminding the caller to include
+``cascade_delete=1``. For example usage, see ``tests/test_flask_config.py``.
+
+Cascade deletes permanently remove related data. Use with caution to avoid
+accidental data loss.
+
 .. _advanced-callbacks:
 
 Callbacks, validators and hooks


### PR DESCRIPTION
## Summary
- document API_ALLOW_CASCADE_DELETE and cascade_delete flag

## Testing
- `ruff check .`
- `pytest` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689cdf7b23c08322aa3ebea40b93922f