### PR TITLE
docs: document field and schema case options

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -1,8 +1,8 @@
 Advanced Configuration
 ======================
 
-Beyond the basics, **flarchitect** offers several advanced options for fine-tuning
-API behaviour. This guide covers rate limiting and cache configuration.
+Beyond the basics, **flarchitect** offers several advanced options for fine-
+tuning API behaviour. This guide covers rate limiting and cache configuration.
 
 Rate limiting
 -------------
@@ -90,6 +90,71 @@ The following snippet enables CORS for all API routes::
 See the :doc:`configuration <configuration>` page for the full list of
 available CORS settings.
 
+Case style configuration
+------------------------
+
+``flarchitect`` can reshape field and schema names to match different
+case conventions. These options keep the API's payloads, schemas and
+endpoints consistent with the style used by your clients.
+
+``API_FIELD_CASE``
+^^^^^^^^^^^^^^^^^^
+
+Controls the casing for fields in JSON responses. By default, field names
+use ``snake`` case. Setting ``API_FIELD_CASE`` changes the output to match
+other naming styles:
+
+.. code-block:: python
+
+    class Config:
+        API_FIELD_CASE = "camel"
+
+.. code-block:: json
+
+    {
+        "statusCode": 200,
+        "value": {
+            "publicationDate": "2024-05-10"
+        }
+    }
+
+Switching to ``kebab`` case instead renders the same field as
+``publication-date``. Supported options include ``snake``, ``camel``,
+``pascal``, ``kebab`` and ``screaming_snake``.
+
+``API_SCHEMA_CASE``
+^^^^^^^^^^^^^^^^^^^
+
+Defines the naming convention for generated schema names in the OpenAPI
+document. The default, ``camel``, produces schema identifiers such as
+``apiCalls``. Other styles are also available:
+
+.. code-block:: python
+
+    class Config:
+        API_SCHEMA_CASE = "screaming_snake"
+
+.. code-block:: json
+
+    {
+        "components": {
+            "schemas": {
+                "API_CALLS": {
+                    "...": "..."
+                }
+            }
+        }
+    }
+
+Interplay with ``API_ENDPOINT_CASE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``API_ENDPOINT_CASE`` controls the casing of the generated URL paths. To
+maintain a consistent style across paths, schemas and payloads, combine
+``API_ENDPOINT_CASE`` with the appropriate ``API_FIELD_CASE`` and
+``API_SCHEMA_CASE`` values. For example, selecting ``kebab`` endpoint
+casing pairs naturally with ``kebab`` field names.
+
 .. _advanced-callbacks:
 
 Callbacks, validators and hooks
@@ -122,8 +187,9 @@ responses are constructed.
 Custom validators
 ^^^^^^^^^^^^^^^^^
 
-Attach validators to SQLAlchemy columns via the ``info`` mapping. Validators are
-looked up in :mod:`flarchitect.schemas.validators` and applied automatically.
+Attach validators to SQLAlchemy columns via the ``info`` mapping. Validators
+are looked up in :mod:`flarchitect.schemas.validators` and applied
+automatically.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Summary
- document API_FIELD_CASE and API_SCHEMA_CASE in advanced configuration
- show example outputs for different case styles
- note how API_ENDPOINT_CASE interacts with field and schema naming

## Testing
- `doc8 docs/source/advanced_configuration.rst`
- `ruff check .`
- `pytest` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689cdf819c108322ace2fd5fd128b73f