### PR TITLE
docs: reorganize index toctrees

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,24 +2,35 @@ flarchitect
 =========================================
 
 .. toctree::
-   :hidden:
    :maxdepth: 2
-   :caption: Contents:
+   :caption: Beginner
+   :hidden:
 
    installation
    quickstart
    getting_started
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Guides
+   :hidden:
+
    models
    validation
    authentication
    callbacks
    configuration
-   advanced_configuration
    openapi
    soft_delete
-   advanced_demo
    faq
-   genindex
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Advanced
+   :hidden:
+
+   advanced_configuration
+   advanced_demo
 
 .. image:: /_static/coverage.svg
    :alt: Coverage Report


### PR DESCRIPTION
## Summary
- split index toctree into beginner, guide, and advanced sections
- drop explicit genindex entry so Sphinx generates index automatically

## Testing
- `ruff check docs/source/index.rst` *(fails: SyntaxError: Expected ',' due to non-Python file)*
- `ruff format docs/source/index.rst` *(fails: Failed to parse docs/source/index.rst: Expected a statement)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_689ce218ca1083228815b4e1423f326e