### PR TITLE
chore: unify repository links and fix roles import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # flarchitect
 
-[![Docs](https://github.com/lewis-morris/flarchitect/actions/workflows/docs.yml/badge.svg?branch=master)](https://github.com/lewis-morris/flarchitect/actions/workflows/docs.yml)
-[![Tests](https://github.com/lewis-morris/flarchitect/actions/workflows/run-unit-tests.yml/badge.svg?branch=master)](https://github.com/lewis-morris/flarchitect/actions/workflows/run-unit-tests.yml)
-![Coverage](https://lewis-morris.github.io/flarchitect/_static/coverage.svg)
+[![Docs](https://github.com/arched-dev/flarchitect/actions/workflows/docs.yml/badge.svg?branch=master)](https://github.com/arched-dev/flarchitect/actions/workflows/docs.yml)
+[![Tests](https://github.com/arched-dev/flarchitect/actions/workflows/run-unit-tests.yml/badge.svg?branch=master)](https://github.com/arched-dev/flarchitect/actions/workflows/run-unit-tests.yml)
+![Coverage](https://arched-dev.github.io/flarchitect/_static/coverage.svg)
 
 
 flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQLAlchemy models into a production-ready REST API with almost no boilerplate. It automatically builds CRUD endpoints, generates interactive Redoc documentation and keeps responses consistent so you can focus on your application logic.
@@ -77,7 +77,7 @@ pytest
 
 ## Documentation & help
 
-- Browse the [full documentation](https://lewis-morris.github.io/flarchitect/) for tutorials and API reference.
+- Browse the [full documentation](https://arched-dev.github.io/flarchitect/) for tutorials and API reference.
 - Explore runnable examples in the [demo](https://github.com/arched-dev/flarchitect/tree/master/demo) directory.
 - Questions? Join the [GitHub discussions](https://github.com/arched-dev/flarchitect/discussions) or open an [issue](https://github.com/arched-dev/flarchitect/issues).
 

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -13,10 +13,10 @@ from flask_limiter.util import get_remote_address
 from marshmallow import Schema
 from sqlalchemy.orm import DeclarativeBase
 
-
 if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
     from flask_caching import Cache
 
+from flarchitect.authentication import roles_required
 from flarchitect.authentication.jwt import get_user_from_token
 from flarchitect.authentication.user import set_current_user
 from flarchitect.core.routes import RouteCreator, find_rule_by_function


### PR DESCRIPTION
## Summary
- update README links to canonical arched-dev repository
- import roles_required in architect to satisfy linter

## Testing
- `ruff check --fix .`
- `pytest` *(fails: ImportError cannot import name 'Architect')*

------
https://chatgpt.com/codex/tasks/task_e_689ce2142b4c83228892890aad9a2ad1