### PR TITLE
Fix test module stubbing and allow in-memory rate limit backend

### DIFF
--- a/flarchitect/utils/general.py
+++ b/flarchitect/utils/general.py
@@ -173,11 +173,17 @@ def check_rate_services() -> str | None:
     uri = get_config_or_model_meta("API_RATE_LIMIT_STORAGE_URI", default=None)
     if uri:
         parsed = urlparse(uri)
-        scheme_map = {"memcached": "Memcached", "redis": "Redis", "mongodb": "MongoDB"}
-        service_name = scheme_map.get(parsed.scheme)
-        if service_name is None:
+        scheme_map = {
+            "memcached": "Memcached",
+            "redis": "Redis",
+            "mongodb": "MongoDB",
+            "memory": None,
+        }
+        if parsed.scheme not in scheme_map:
             raise ValueError(f"Unsupported rate limit storage backend: {parsed.scheme}")
-        check_rate_prerequisites(service_name)
+        service_name = scheme_map[parsed.scheme]
+        if service_name:
+            check_rate_prerequisites(service_name)
         return uri
 
     for service, port in services.items():

--- a/tests/test_handle_result.py
+++ b/tests/test_handle_result.py
@@ -5,6 +5,18 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+# Store existing module references so later tests can import the real package
+ORIGINAL_MODULES = {
+    name: sys.modules.get(name)
+    for name in [
+        "flarchitect",
+        "flarchitect.utils",
+        "flarchitect.utils.core_utils",
+        "flarchitect.utils.config_helpers",
+        "flarchitect.utils.general",
+    ]
+}
+
 # Create stub packages to avoid executing flarchitect.__init__
 flarchitect_pkg = types.ModuleType("flarchitect")
 flarchitect_pkg.__path__ = [str(ROOT / "flarchitect")]
@@ -37,6 +49,13 @@ spec_general.loader.exec_module(general)
 handle_result = general.handle_result
 HTTP_OK = general.HTTP_OK
 HTTP_INTERNAL_SERVER_ERROR = general.HTTP_INTERNAL_SERVER_ERROR
+
+# Restore any original modules so later imports see the real package
+for name, module in ORIGINAL_MODULES.items():
+    if module is not None:
+        sys.modules[name] = module
+    else:
+        sys.modules.pop(name, None)
 
 
 def test_handle_result_with_dict():


### PR DESCRIPTION
## Summary
- ensure test_handle_result restores real flarchitect modules after stubbing
- allow `memory://` rate limit storage URIs in `check_rate_services`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce4ed28ac8322b7bfabbf4e34fc1a