### PR TITLE
docs: expand configuration reference

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -380,7 +380,9 @@
         - Rate limit string using Flask-Limiter syntax (e.g., ``100/minute``) to throttle requests. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
     * - ``API_RATE_LIMIT_CALLBACK``
 
-          :bdg-secondary:`Optional` 
+          :bdg:`default:` ``None``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - Custom callback executed when a rate limit is hit, enabling logging or alternative responses.
     * - ``API_RATE_LIMIT_STORAGE_URI``
@@ -392,23 +394,30 @@
         - Storage backend for rate limit data such as ``redis://`` or ``memory://``.
     * - ``IGNORE_FIELDS``
 
-          :bdg-secondary:`Optional` 
+          :bdg:`default:` ``None``
+          :bdg:`type` ``list[str]``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
         - Fields to exclude entirely from both input and output payloads.
     * - ``IGNORE_OUTPUT_FIELDS``
 
-          :bdg-secondary:`Optional` 
+          :bdg:`default:` ``None``
+          :bdg:`type` ``list[str]``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
         - Fields removed from output serialization while still accepted on input.
     * - ``IGNORE_INPUT_FIELDS``
 
-          :bdg-secondary:`Optional` 
+          :bdg:`default:` ``None``
+          :bdg:`type` ``list[str]``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
         - Input-only fields stripped from response bodies but required on create or update.
     * - ``API_BLUEPRINT_NAME``
 
           :bdg:`default:` ``None``
-          :bdg-secondary:`Optional` 
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - Name given to the Flask blueprint that houses the API routes. Useful for namespacing.
     * - ``API_SOFT_DELETE``
@@ -448,21 +457,29 @@
         - Permits deletion of dependent objects that rely on the target record.
     * - ``GET_MANY_SUMMARY``
 
-          :bdg-secondary:`Optional` 
+          :bdg:`default:` ``None``
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
         - Short description for list endpoints used in generated docs.
     * - ``GET_SINGLE_SUMMARY``
 
-          :bdg-secondary:`Optional` 
+          :bdg:`default:` ``None``
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
         - Summary shown in docs for retrieving a single record.
     * - ``POST_SUMMARY``
 
-          :bdg-secondary:`Optional` 
+          :bdg:`default:` ``None``
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
         - Brief explanation of the create operation in documentation.
     * - ``PATCH_SUMMARY``
 
-          :bdg-secondary:`Optional` 
+          :bdg:`default:` ``None``
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
         - Short description for partial update operations.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -14,8 +14,10 @@ Configuration
 Intro
 --------------------------------
 
-In `flarchitect`, configuration options are essential for customizing the API and its accompanying documentation.  
+In `flarchitect`, configuration options are essential for customizing the API and its accompanying documentation.
 These settings can be provided through `Flask`_ config values or directly within `SQLAlchemy`_ model classes using ``Meta`` classes.
+
+Beyond the basics, the extension supports hooks and advanced flags for post-serialization callbacks, rate limiting, field exclusion, blueprint naming, soft deletion, and per-method documentation summaries.
 
 `Flask`_ config values offer a straightforward, standardized way to modify the extension's behavior at a global or model level.
 


### PR DESCRIPTION
## Summary
- document API_RATE_LIMIT_CALLBACK and ignore field lists
- clarify blueprint naming and per-method summary options

## Testing
- `ruff format docs/source/configuration.rst docs/source/_configuration_table.rst` (fails: Expected a statement)
- `ruff check flarchitect tests` (fails: SIM118, F811, etc.)
- `pytest` (fails: ModuleNotFoundError: No module named 'flask')

------
https://chatgpt.com/codex/tasks/task_e_689ce5a1608c832288fb385b4bc31834