### PR TITLE
docs: document cascade delete options

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -214,9 +214,52 @@ function to a field name::
 
     GET /api/books?groupby=author_id&id|book_count__count=1
 
+.. _cascade-deletes:
+
 Cascade deletes
 ---------------
 
+When removing a record, related rows may block the operation. These
+settings let ``flarchitect`` clean up relationships automatically when
+explicitly requested.
+
+:data:`API_ALLOW_CASCADE_DELETE` permits clients to trigger cascading
+removal by adding ``?cascade_delete=1`` to the request. Without this
+flag or query parameter, deletes that would orphan related records raise
+``409 Conflict`` instead of proceeding::
+
+    DELETE /api/books/1?cascade_delete=1
+
+.. code-block:: python
+
+    class Config:
+        API_ALLOW_CASCADE_DELETE = True
+
+:data:`API_ALLOW_DELETE_RELATED` governs whether child objects referencing
+the target can be removed automatically. Disable it to require manual
+cleanup of related rows:
+
+.. code-block:: python
+
+    class Book(db.Model):
+        class Meta:
+            delete_related = False  # API_ALLOW_DELETE_RELATED
+
+:data:`API_ALLOW_DELETE_DEPENDENTS` covers dependent objects such as
+association table entries. Turning it off forces clients to delete those
+records explicitly:
+
+.. code-block:: python
+
+    class Book(db.Model):
+        class Meta:
+            delete_dependents = False  # API_ALLOW_DELETE_DEPENDENTS
+
+See :doc:`configuration <configuration>` for default values and additional
+context on these options.
+
+Case conventions
+----------------
 
 ``flarchitect`` can reshape field and schema names to match different
 case conventions. These options keep the API's payloads, schemas and

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -162,6 +162,14 @@ Please note the badge for each configuration value, as it defines where the valu
         See the :doc:`Model Method<config_locations/model_method>` page for more information.
 
 
+Cascade delete settings
+-----------------------
+
+See :ref:`cascade-deletes` in the advanced configuration guide for usage examples of
+:data:`API_ALLOW_CASCADE_DELETE`, :data:`API_ALLOW_DELETE_RELATED` and
+:data:`API_ALLOW_DELETE_DEPENDENTS`.
+
+
 Complete Configuration Reference
 --------------------------------
 


### PR DESCRIPTION
## Summary
- document cascade delete settings and usage examples
- cross-reference cascade delete configuration options

## Testing
- `ruff check flarchitect`
- `pytest -q` *(fails: ImportError: cannot import name 'Architect')*

------
https://chatgpt.com/codex/tasks/task_e_689cea94ee8483229c4024c1775d545f