### PR TITLE
docs: document roles_required decorator

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -5,6 +5,8 @@ flarchitect provides several helpers so you can secure your API quickly.
 Enable one or more strategies via ``API_AUTHENTICATE_METHOD``. Available
 methods are ``jwt``, ``basic``, ``api_key`` and ``custom``. Each example below
 uses the common setup defined in ``demo/authentication/app_base.py``.
+You can also protect routes based on user roles using the
+:ref:`roles-required` decorator.
 
 Error responses
 ---------------
@@ -189,6 +191,36 @@ Clients can then call your API with whatever headers your function expects:
    curl -H "X-Token: <token>" http://localhost:5000/api/books
 
 See ``demo/authentication/custom_auth.py`` for this approach in context.
+
+.. _roles-required:
+
+Role-based access
+-----------------
+
+Use the ``roles_required`` decorator to allow only users with specific roles to
+access an endpoint. The decorator checks the ``roles`` attribute on
+``current_user`` which is populated by the active authentication method.
+
+.. code-block:: python
+
+   from flarchitect.authentication import roles_required
+
+   @app.get("/admin")
+   @roles_required("admin")
+   def admin_dashboard():
+       return {"status": "ok"}
+
+You can require multiple roles by passing more than one name:
+
+.. code-block:: python
+
+   @roles_required("admin", "editor")
+   def update_post():
+       ...
+
+Ensure your user model exposes a list of role names, for example
+``User.roles = ["admin", "editor"]``. If the authenticated user lacks any of
+the required roles—or if no user is authenticated—a ``403`` response is raised.
 
 Troubleshooting
 ---------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,6 +59,7 @@ What can it do?
 * Automatically detect and create endpoints, including nested relationships.
 * Standardise responses with a consistent structure.
 * Authenticate users with JWT access and refresh tokens.
+* Restrict endpoints to specific roles with :ref:`roles-required`.
 * Add configurable rate limits backed by Redis, Memcached or MongoDB.
 * Be configured globally in `Flask`_ or per model via ``Meta`` attributes.
 * Generate `Redoc`_ or Swagger UI documentation on the fly.


### PR DESCRIPTION
## Summary
- document the `roles_required` decorator and its integration with authentication
- link role-based access control from index

## Testing
- `ruff check --fix .`
- `ruff format .`
- `pytest` *(fails: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689cea9678b48322b3ba29ce735e5aec