### PR TITLE
Clarify paginate_query return type

### DIFF
--- a/flarchitect/database/operations.py
+++ b/flarchitect/database/operations.py
@@ -39,7 +39,7 @@ __all__ = [
 ]
 
 
-def paginate_query(sql_query: Query, page: int = 0, items_per_page: int | None = None) -> Query:
+def paginate_query(sql_query: Query, page: int = 0, items_per_page: int | None = None) -> tuple[Query, int]:
     """Applies pagination to a query.
 
     Args:
@@ -48,10 +48,11 @@ def paginate_query(sql_query: Query, page: int = 0, items_per_page: int | None =
         items_per_page (int): Number of items per page.
 
     Returns:
-        Query: Paginated query.
+        tuple[Query, int]:
+            A tuple containing the paginated query and the default pagination size.
     """
 
-    def validate_pagination_params(page: int, items_per_page: int):
+    def validate_pagination_params(page: int, items_per_page: int) -> None:
         """Validate pagination parameters.
 
         Args:

--- a/tests/test_paginate_query.py
+++ b/tests/test_paginate_query.py
@@ -1,0 +1,21 @@
+import pytest
+
+from demo.basic_factory.basic_factory import create_app
+from demo.basic_factory.basic_factory.extensions import db
+from demo.basic_factory.basic_factory.models import Book
+from flarchitect.database.operations import paginate_query
+
+
+@pytest.fixture
+def app():
+    """Create a demo application for testing."""
+    return create_app()
+
+
+def test_paginate_query_returns_paginated_query_and_default(app):
+    """Paginate a query and return default pagination size."""
+    with app.app_context():
+        query = db.session.query(Book)
+        paginated, default_size = paginate_query(query, page=1, items_per_page=1)
+        assert len(paginated.items) == 1
+        assert default_size == 20


### PR DESCRIPTION
## Summary
- refine paginate_query to return a `(Query, int)` tuple and document both values
- test paginate_query to ensure both tuple elements are returned

## Testing
- `ruff check flarchitect/database/operations.py tests/test_paginate_query.py`
- `pytest tests/test_paginate_query.py`


------
https://chatgpt.com/codex/tasks/task_e_689ceac014988322b99cd832014bc0fb