### PR TITLE
docs: clarify callback configuration keys

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -283,9 +283,44 @@
         - Name of the authentication method used, such as ``jwt`` or ``basic``. Determines which auth backend to apply. Example: `tests/test_authentication.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_authentication.py>`_.
     * - ``API_USER_MODEL``
 
-          :bdg-secondary:`Optional` 
+          :bdg-secondary:`Optional`
 
         - Import path for the user model leveraged during authentication workflows. Example: `tests/test_authentication.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_authentication.py>`_.
+    * - ``API_GLOBAL_SETUP_CALLBACK``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Runs before any model-specific processing. Use method-specific variants like ``API_GET_GLOBAL_SETUP_CALLBACK`` to target individual HTTP methods.
+    * - ``API_FILTER_CALLBACK``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
+        - Adjusts the SQLAlchemy query before filters or pagination are applied.
+    * - ``API_ADD_CALLBACK``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
+        - Invoked prior to committing a new object to the database.
+    * - ``API_UPDATE_CALLBACK``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
+        - Called before persisting changes to an existing object.
+    * - ``API_REMOVE_CALLBACK``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
+        - Executed before deleting an object from the database.
     * - ``API_SETUP_CALLBACK``
 
           :bdg:`default:` ``None``
@@ -304,16 +339,23 @@
 
           :bdg:`default:` ``None``
           :bdg:`type` ``callable``
-          :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - Error-handling hook allowing custom formatting or logging of exceptions. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - ``API_POST_DUMP_CALLBACK``
+    * - ``API_DUMP_CALLBACK``
 
           :bdg:`default:` ``None``
           :bdg:`type` ``callable``
           :bdg-secondary:`Optional` :bdg-dark-line:`Model Method`
 
-        - Post-serialization hook to further transform or audit the output data before it is returned.
+        - Post-serialization hook to adjust data after Marshmallow dumping.
+    * - ``API_FINAL_CALLBACK``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Executes just before the response is serialized and returned to the client.
     * - ``API_ADDITIONAL_QUERY_PARAMS``
 
           :bdg:`default:` ``None``

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -11,37 +11,38 @@ Callback types
 flarchitect recognises a number of callback hooks that allow you to run custom
 logic at various stages of processing:
 
-* **Global setup** – runs before any model-specific processing.
+* **Global setup** – runs before any model-specific processing. ``GLOBAL_SETUP_CALLBACK`` (global: ``API_GLOBAL_SETUP_CALLBACK``)
 * **Setup** – runs before database operations. Useful for validation, logging
-  or altering incoming data.
+  or altering incoming data. ``SETUP_CALLBACK`` (global: ``API_SETUP_CALLBACK``)
 * **Filter** – lets you adjust the SQLAlchemy query object before filtering and
-  pagination are applied.
-* **Add** – called before a new object is committed to the database.
-* **Update** – invoked prior to persisting updates to an existing object.
-* **Remove** – executed before an object is deleted.
+  pagination are applied. ``FILTER_CALLBACK`` (global: ``API_FILTER_CALLBACK``)
+* **Add** – called before a new object is committed to the database. ``ADD_CALLBACK`` (global: ``API_ADD_CALLBACK``)
+* **Update** – invoked prior to persisting updates to an existing object. ``UPDATE_CALLBACK`` (global: ``API_UPDATE_CALLBACK``)
+* **Remove** – executed before an object is deleted. ``REMOVE_CALLBACK`` (global: ``API_REMOVE_CALLBACK``)
 * **Return** – runs after the database operation but before the response is
-  returned. Ideal for adjusting the output or adding headers.
+  returned. Ideal for adjusting the output or adding headers. ``RETURN_CALLBACK`` (global: ``API_RETURN_CALLBACK``)
 * **Dump** – executes after Marshmallow serialisation allowing you to modify
-  the dumped data.
-* **Final** – runs immediately before the response is sent to the client.
+  the dumped data. ``DUMP_CALLBACK`` (global: ``API_DUMP_CALLBACK``)
+* **Final** – runs immediately before the response is sent to the client. ``FINAL_CALLBACK`` (global: ``API_FINAL_CALLBACK``)
 * **Error** – triggered when an exception bubbles up; handle logging or
-  notifications here.
+  notifications here. ``ERROR_CALLBACK`` (global: ``API_ERROR_CALLBACK``)
 
 Configuration
 -------------
 
-Callbacks are referenced by the following configuration keys:
+Callbacks are referenced by the following configuration keys (global variants
+use ``API_<KEY>``):
 
-* ``GLOBAL_SETUP_CALLBACK``
-* ``SETUP_CALLBACK``
-* ``FILTER_CALLBACK``
-* ``ADD_CALLBACK``
-* ``UPDATE_CALLBACK``
-* ``REMOVE_CALLBACK``
-* ``RETURN_CALLBACK``
-* ``DUMP_CALLBACK``
-* ``FINAL_CALLBACK``
-* ``ERROR_CALLBACK``
+* ``GLOBAL_SETUP_CALLBACK`` / ``API_GLOBAL_SETUP_CALLBACK``
+* ``SETUP_CALLBACK`` / ``API_SETUP_CALLBACK``
+* ``FILTER_CALLBACK`` / ``API_FILTER_CALLBACK``
+* ``ADD_CALLBACK`` / ``API_ADD_CALLBACK``
+* ``UPDATE_CALLBACK`` / ``API_UPDATE_CALLBACK``
+* ``REMOVE_CALLBACK`` / ``API_REMOVE_CALLBACK``
+* ``RETURN_CALLBACK`` / ``API_RETURN_CALLBACK``
+* ``DUMP_CALLBACK`` / ``API_DUMP_CALLBACK``
+* ``FINAL_CALLBACK`` / ``API_FINAL_CALLBACK``
+* ``ERROR_CALLBACK`` / ``API_ERROR_CALLBACK``
 
 You can apply these keys in several places:
 


### PR DESCRIPTION
## Summary
- document callback configuration keys and scopes in the configuration table
- link callback types to their configuration keys and global variants

## Testing
- `ruff format .`
- `ruff check .`
- `pytest` *(fails: cannot import name 'Architect' from 'flarchitect')*

------
https://chatgpt.com/codex/tasks/task_e_689cea9878648322b7a02c25d3bc2272