### PR TITLE
docs: document API configuration options

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -7,6 +7,13 @@
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - Controls whether ReDoc documentation is generated automatically. Set to ``False`` to disable docs in production or when using an external documentation tool. Accepts ``True`` or ``False``. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``API_DOCUMENTATION_HEADERS``
+
+          :bdg:`default:` ````
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Extra HTML placed in the <head> of the docs page. Supply meta tags or script includes as a string or template.
     * - ``API_DOCUMENTATION_URL``
 
           :bdg:`default:` ``/docs``
@@ -14,6 +21,13 @@
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - URL path where documentation is served. Useful for mounting docs under a custom route such as ``/redoc``. Accepts any valid path string. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``API_DOCS_STYLE``
+
+          :bdg:`default:` ``redoc``
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Selects the documentation UI style. Use ``redoc`` (default) or ``swagger`` to render with Swagger UI.
     * - ``API_SPEC_ROUTE``
 
           :bdg:`default:` ``/openapi.json``
@@ -139,6 +153,13 @@
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - Case style for generated endpoint URLs such as ``kebab`` or ``snake``. Choose to match your project's conventions. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``API_ENDPOINT_NAMER``
+
+          :bdg:`default:` ``endpoint_namer``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Function that generates endpoint names from models. Override to customise URL naming behaviour.
     * - ``API_FIELD_CASE``
 
           :bdg:`default:` ``snake``
@@ -266,6 +287,13 @@
           :bdg-secondary:`Optional` :bdg-dark-line:`Model`
 
         - Allows clients to specify which fields to return, reducing payload size. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``API_ALLOWED_METHODS``
+
+          :bdg:`default:` ``[]``
+          :bdg:`type` ``list[str]``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Model`
+
+        - Whitelist of HTTP methods permitted on routes. Only methods in this list are enabled.
     * - ``API_block_methods``
 
           :bdg-secondary:`Optional` 
@@ -281,6 +309,13 @@
           :bdg-secondary:`Optional` 
 
         - Name of the authentication method used, such as ``jwt`` or ``basic``. Determines which auth backend to apply. Example: `tests/test_authentication.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_authentication.py>`_.
+    * - ``API_CREDENTIAL_HASH_FIELD``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Field on the user model storing a hashed credential for API key auth. Required when using ``api_key`` authentication.
     * - ``API_USER_MODEL``
 
           :bdg-secondary:`Optional` 

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -128,6 +128,7 @@ API key auth associates a user with a single token. Clients send the token in
 each request, usually via a header like ``X-API-Key`` or as a query string
 parameter. flarchitect passes the token to a function you provide, and the
 function returns the matching user.
+If you store hashed tokens on the model, set ``API_CREDENTIAL_HASH_FIELD`` to the attribute holding the hash so flarchitect can validate keys.
 
 Attach a function that accepts an API key and returns a user. The function can
 also call ``set_current_user``:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -17,7 +17,7 @@ Intro
 In `flarchitect`, configuration options are essential for customizing the API and its accompanying documentation.
 These settings can be provided through `Flask`_ config values or directly within `SQLAlchemy`_ model classes using ``Meta`` classes.
 
-Beyond the basics, the extension supports hooks and advanced flags for post-serialization callbacks, rate limiting, field exclusion, blueprint naming, soft deletion, and per-method documentation summaries.
+Beyond the basics, the extension supports hooks and advanced flags for post-serialization callbacks, rate limiting, field exclusion, blueprint naming, endpoint naming via ``API_ENDPOINT_NAMER``, soft deletion, and per-method documentation summaries.
 
 `Flask`_ config values offer a straightforward, standardized way to modify the extension's behavior at a global or model level.
 

--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -4,8 +4,9 @@ OpenAPI Specification
 flarchitect automatically generates an OpenAPI 3.0.2 document for every
 registered model. The specification powers the interactive Redoc page and
 can also be rendered with Swagger UI by setting ``API_DOCS_STYLE = 'swagger'``
-in your Flask configuration. The raw spec can also be reused with external
-tools like Postman.
+in your Flask configuration. You can inject additional `<head>` tags into
+the documentation with ``API_DOCUMENTATION_HEADERS``. The raw spec can also be
+reused with external tools like Postman.
 
 Automatic generation
 --------------------
@@ -38,6 +39,8 @@ Customising the document
 
 A number of configuration keys let you tailor the output:
 
+* ``API_DOCS_STYLE`` – choose between Redoc and Swagger UI
+* ``API_DOCUMENTATION_HEADERS`` – inject extra HTML into the docs page
 * ``API_TITLE`` – title displayed in the document
 * ``API_VERSION`` – semantic version string
 * ``API_DESCRIPTION`` – path to a README-style file rendered into the


### PR DESCRIPTION
## Summary
- document API_DOCS_STYLE, API_DOCUMENTATION_HEADERS and API_ENDPOINT_NAMER
- add API_ALLOWED_METHODS and API_CREDENTIAL_HASH_FIELD to configuration table
- cross-reference new configuration keys in OpenAPI, configuration and authentication guides

## Testing
- `ruff check --fix .`
- `pytest` *(fails: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689cea9b4ac883228e139f3c18acb9df