### PR TITLE
docs: expand installation guide

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,8 +1,44 @@
 Installation
 =========================================
 
-Install couldn't be easier. Just install with :program:`pip`.
+Creating a Virtual Environment
+------------------------------
+Using a virtual environment keeps dependencies isolated. Create and activate one
+with :mod:`venv`::
 
-.. code:: console
+  $ python -m venv .venv
+  $ source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
 
-  $ pip install flarchitect
+Minimum Requirements
+--------------------
+* Python 3.10+
+* Flask 2.2.5+
+* SQLAlchemy 1.4+ (via :mod:`flask_sqlalchemy` 3.0.5+)
+
+Install FLArchitect
+-------------------
+Once the environment is active, install with :program:`pip`::
+
+  (.venv) $ pip install flarchitect
+
+Verify the Installation
+-----------------------
+Run a tiny script to ensure everything works. Create ``verify.py``::
+
+  from flarchitect import Architect
+  from flask import Flask
+
+  app = Flask(__name__)
+  architect = Architect(app)
+
+  print("FLArchitect is ready!")
+
+Then execute it::
+
+  (.venv) $ python verify.py
+
+Troubleshooting
+---------------
+* **Missing compiler**: install system build tools (e.g. ``build-essential`` on Ubuntu or Xcode command line tools on macOS).
+* **Proxy issues**: set ``HTTP_PROXY``/``HTTPS_PROXY`` environment variables or pass ``--proxy`` to :program:`pip`.
+


### PR DESCRIPTION
## Summary
- document virtual environment setup, minimum versions, and install steps
- add verification script and troubleshooting tips for common install issues

## Testing
- `ruff check --fix docs/source/installation.rst` *(fails: SyntaxError: Expected a statement)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689cf34a4bb08322b6cd8f80973fb6ba