### PR TITLE
Add caching demo and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pytest
 ## Documentation & help
 
 - Browse the [full documentation](https://lewis-morris.github.io/flarchitect/) for tutorials and API reference.
-- Explore runnable examples in the [demo](https://github.com/lewis-morris/flarchitect/tree/master/demo) directory.
+- Explore runnable examples in the [demo](https://github.com/lewis-morris/flarchitect/tree/master/demo) directory, including a [caching example](https://github.com/lewis-morris/flarchitect/tree/master/demo/caching).
 - Questions? Join the [GitHub discussions](https://github.com/lewis-morris/flarchitect/discussions) or open an [issue](https://github.com/lewis-morris/flarchitect/issues).
 - See the [changelog](CHANGES.rst) for release history.
 

--- a/demo/caching/README.md
+++ b/demo/caching/README.md
@@ -1,0 +1,14 @@
+# Caching Demo
+
+This example shows how **flarchitect** caches GET responses. The cache backend is selected with `API_CACHE_TYPE` and entries expire after `API_CACHE_TIMEOUT` seconds.
+
+If `flask_caching` is installed, its `Cache` class backs the demo. Otherwise it falls back to the lightweight `SimpleCache` implementation bundled with flarchitect.
+
+## Run
+
+```bash
+pip install 'flarchitect[cache]'  # enables flask-caching
+python demo/caching/app.py
+```
+
+Requests to `/api/authors/1` will return cached data until the timeout expires. The `/time` route demonstrates caching on a custom endpoint.

--- a/demo/caching/app.py
+++ b/demo/caching/app.py
@@ -1,0 +1,95 @@
+"""Demo application showcasing response caching.
+
+The app exposes a single ``Author`` model with a generated REST API. GET
+responses are cached using the backend configured via ``API_CACHE_TYPE``.
+``API_CACHE_TIMEOUT`` controls how long each cache entry lives. When the
+``flask_caching`` package is installed the demo uses its ``Cache`` class; if
+not, it falls back to :class:`flarchitect.core.simple_cache.SimpleCache`.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from flarchitect import Architect
+
+
+class BaseModel(DeclarativeBase):
+    """Base model providing ``get_session`` for flarchitect."""
+
+    def get_session(*args: Any) -> Any:  # type: ignore[no-untyped-def]
+        return db.session
+
+
+db = SQLAlchemy(model_class=BaseModel)
+
+
+class Author(db.Model):
+    """Simple author model used for demonstration."""
+
+    __tablename__ = "author"
+
+    class Meta:
+        tag_group = "People/Companies"
+        tag = "Author"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    first_name: Mapped[str] = mapped_column(String)
+
+
+def create_app(config: dict | None = None) -> Flask:
+    """Application factory enabling response caching.
+
+    The returned app caches GET responses. ``API_CACHE_TYPE`` selects the cache
+    backend while ``API_CACHE_TIMEOUT`` defines the expiration in seconds.
+
+    Args:
+        config: Optional mapping to override default configuration.
+
+    Returns:
+        Configured :class:`~flask.Flask` instance.
+    """
+
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        API_TITLE="Caching Demo",
+        API_VERSION="1.0",
+        API_BASE_MODEL=db.Model,
+        API_CACHE_TYPE="SimpleCache",
+        API_CACHE_TIMEOUT=1,
+    )
+    if config:
+        app.config.update(config)
+
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        db.session.add(Author(first_name="Initial"))
+        db.session.commit()
+
+        architect = Architect(app)
+
+        @app.route("/time")
+        @architect.cache.cached()
+        def current_time() -> dict[str, float]:
+            """Return the current epoch time.
+
+            The value is cached, so repeated calls within the timeout return
+            the same response. After ``API_CACHE_TIMEOUT`` seconds, the cache is
+            invalidated and a new timestamp is generated.
+            """
+
+            return {"time": time.time()}
+
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    create_app().run(debug=True)

--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -51,6 +51,8 @@ storage URI:
 If no backend is available, the limiter falls back to in-memory storage
 with rate-limit headers enabled by default.
 
+For a runnable example demonstrating cached responses see the `caching demo <https://github.com/lewis-morris/flarchitect/tree/master/demo/caching>`_.
+
 Response metadata
 -----------------
 

--- a/tests/test_demo_caching.py
+++ b/tests/test_demo_caching.py
@@ -1,0 +1,23 @@
+import time
+
+from demo.caching.app import Author, create_app, db
+
+
+def test_cached_endpoint_stores_and_invalidates_response():
+    app = create_app({"API_CACHE_TIMEOUT": 1})
+    client = app.test_client()
+
+    first = client.get("/api/authors/1").get_json()["value"]["first_name"]
+
+    with app.app_context():
+        author = db.session.get(Author, 1)
+        author.first_name = "Cached"
+        db.session.commit()
+
+    second = client.get("/api/authors/1").get_json()["value"]["first_name"]
+    assert second == first
+
+    time.sleep(1.1)
+
+    third = client.get("/api/authors/1").get_json()["value"]["first_name"]
+    assert third == "Cached"


### PR DESCRIPTION
## Summary
- add caching demo showing flask-caching and SimpleCache usage
- document cache configuration keys and link demo in docs
- test cached endpoint behaviour

## Testing
- `ruff check --fix demo/caching/app.py tests/test_demo_caching.py`
- `pytest tests/test_demo_caching.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf33dd150832280425ddae8f1b8d2