### PR TITLE
Add validators demo and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pytest
 ## Documentation & help
 
 - Browse the [full documentation](https://lewis-morris.github.io/flarchitect/) for tutorials and API reference.
-- Explore runnable examples in the [demo](https://github.com/lewis-morris/flarchitect/tree/master/demo) directory.
+- Explore runnable examples in the [demo](https://github.com/lewis-morris/flarchitect/tree/master/demo) directory, including a [validators example](demo/validators/README.md) showcasing email and URL validation.
 - Questions? Join the [GitHub discussions](https://github.com/lewis-morris/flarchitect/discussions) or open an [issue](https://github.com/lewis-morris/flarchitect/issues).
 - See the [changelog](CHANGES.rst) for release history.
 

--- a/demo/validators/README.md
+++ b/demo/validators/README.md
@@ -1,0 +1,23 @@
+# Validator Demo
+
+This example Flask application showcases how **flarchitect** attaches
+field validators to SQLAlchemy models.  The `User` model defines an
+`email` field with explicit email validation and a `homepage` field with a
+URL validator added via the `format="uri"` hint.
+
+## Running the demo
+
+```bash
+python demo/validators/app.py
+```
+
+Once running, send a POST request with invalid data to see the validators
+in action:
+
+```bash
+curl -X POST http://localhost:5000/api/users \
+     -H 'Content-Type: application/json' \
+     -d '{"email": "not-email", "homepage": "not-url", "slug": "Bad Slug"}'
+```
+
+The API responds with `400` and details of the validation failures.

--- a/demo/validators/__init__.py
+++ b/demo/validators/__init__.py
@@ -1,0 +1,11 @@
+"""Demo application showcasing flarchitect field validators.
+
+This package provides a minimal Flask application demonstrating how
+:func:`flarchitect.schemas.validators.validate_by_type` integrates with
+SQLAlchemy models.  It exposes :func:`create_app` which is used by the
+unit tests and can be executed directly.
+"""
+
+from .app import User, create_app, db
+
+__all__ = ["create_app", "db", "User"]

--- a/demo/validators/app.py
+++ b/demo/validators/app.py
@@ -1,0 +1,109 @@
+"""Minimal Flask application illustrating field validators.
+
+The application demonstrates how flarchitect's automatic field validation
+works with SQLAlchemy models.  Each column defines validation rules via
+the ``info`` mapping which ``flarchitect`` interprets to attach the
+appropriate Marshmallow validators.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from flarchitect import Architect
+
+# ``SQLAlchemy`` instance used by the demo app.  ``flarchitect`` will read
+# models from this database when initialised inside :func:`create_app`.
+
+
+class BaseModel(DeclarativeBase):
+    """Base model providing a session accessor for flarchitect."""
+
+    def get_session(*args: Any, **kwargs: Any):
+        """Return the current database session."""
+
+        return db.session
+
+
+# create the SQLAlchemy extension using our BaseModel
+db = SQLAlchemy(model_class=BaseModel)
+
+
+class User(db.Model):
+    """Simple user model with multiple validated fields.
+
+    Attributes:
+        id: Primary key for the user.
+        email: User's email address. ``info={'validate': 'email'}`` triggers
+            the built-in email validator which rejects invalid addresses.
+        homepage: Personal website URL. ``info={'format': 'uri'}`` attaches a
+            URL validator ensuring the string is a valid absolute URI.
+        slug: Public identifier restricted to URL-friendly characters via the
+            ``slug`` validator.
+    """
+
+    __tablename__ = "users"
+
+    class Meta:
+        """Expose the model through the API and group it under ``User``."""
+
+        tag = "User"
+        tag_group = "Demo"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    email: Mapped[str] = mapped_column(
+        String(120),
+        info={"validate": "email"},  # Rejects values that are not emails
+        nullable=False,
+    )
+    homepage: Mapped[str] = mapped_column(
+        String(200),
+        info={"format": "uri"},  # Adds URL validation automatically
+        nullable=False,
+    )
+    slug: Mapped[str] = mapped_column(
+        String(50),
+        info={"validate": "slug"},  # Ensures value is a URL-friendly slug
+        nullable=False,
+    )
+
+
+def create_app(config: dict[str, Any] | None = None) -> Flask:
+    """Build and configure the validator demo application.
+
+    Args:
+        config: Optional mapping to override default configuration values.
+
+    Returns:
+        A Flask application exposing REST endpoints for the :class:`User`
+        model. Invalid field values raise ``ValidationError`` and return a
+        ``400`` response.
+    """
+
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        API_TITLE="Validator API",
+        API_VERSION="1.0",
+        API_BASE_MODEL=db.Model,
+    )
+    if config:
+        app.config.update(config)
+
+    db.init_app(app)
+
+    with app.app_context():
+        db.create_all()
+        # ``Architect`` scans the models and registers CRUD routes.
+        Architect(app)
+
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    create_app().run(debug=True)

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -5,6 +5,8 @@ flarchitect ships with a suite of field validators that hook directly into
 `Marshmallow`_.  Validators can be attached to a model column via the SQLAlchemy
 ``info`` mapping or inferred automatically from column names and formats.
 
+For a runnable example demonstrating email and URL validation see the `validators demo <https://github.com/lewis-morris/flarchitect/tree/master/demo/validators>`_.
+
 Basic usage
 -----------
 

--- a/tests/test_demo_validators.py
+++ b/tests/test_demo_validators.py
@@ -1,0 +1,32 @@
+"""Tests for the validators demo application."""
+
+from __future__ import annotations
+
+import pytest
+from flask.testing import FlaskClient
+
+from demo.validators import create_app
+
+
+@pytest.fixture()
+def client() -> FlaskClient:
+    """Provide a test client for the validator demo app."""
+
+    app = create_app()
+    with app.test_client() as client:
+        yield client
+
+
+def test_validation_errors(client: FlaskClient) -> None:
+    """Invalid field data returns a 400 with error details."""
+
+    response = client.post(
+        "/api/users",
+        json={"email": "not-email", "homepage": "not-url", "slug": "Bad Slug"},
+    )
+    assert response.status_code == 400
+    data = response.get_json()
+    error_fields = data["errors"]["error"]
+    assert "email" in error_fields
+    assert "homepage" in error_fields
+    assert "slug" in error_fields


### PR DESCRIPTION
## Summary
- add `demo/validators` example showing email, URL and slug field validation
- document validator demo in README and validation guide
- test demo app to ensure invalid data triggers validation errors

## Testing
- `ruff format demo/validators/app.py tests/test_demo_validators.py`
- `ruff check --fix demo/validators/app.py tests/test_demo_validators.py`
- `pytest tests/test_demo_validators.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689cf33cc7488322a745d6318d9765fe