### PR TITLE
docs: clarify getting started guide

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -1,8 +1,9 @@
 Getting Started Sample Project
 ==============================
 
-A minimal application that exposes an ``Author`` model through a generated REST API.
-The project lives in ``demo/quickstart/load.py``.
+Flarchitect ships with a tiny demo that shows how it turns a SQLAlchemy model into a REST API.
+The sample lives in ``demo/quickstart/load.py`` and defines a single ``Author`` model.
+Running the script starts a local server and exposes the model at ``/api/author``, returning an empty list until you add data.
 
 .. literalinclude:: ../../demo/quickstart/load.py
    :language: python
@@ -15,3 +16,15 @@ Run the demo
 
    python demo/quickstart/load.py
    curl http://localhost:5000/api/author
+
+The curl command answers with a JSON payload that includes some metadata and a ``value`` list of authors.
+Because the demo starts with no records, that list is empty:
+
+.. code-block:: json
+
+   {
+       "total_count": 0,
+       "value": []
+   }
+
+Pop open ``http://localhost:5000/docs`` in your browser to explore the automatically generated API docs.


### PR DESCRIPTION
## Summary
- expand intro and overview in getting started docs
- explain sample JSON response and link to generated `/docs`

## Testing
- `ruff --fix docs/source/getting_started.rst` *(fails: unexpected argument '--fix')*
- `pytest` *(terminated after 15%: long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_689cf34cbb488322b72272259a499182