### PR TITLE
Generate and reference version badge

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,14 +54,29 @@ jobs:
           mkdir -p docs/source/_static
           cp -f coverage.svg docs/source/_static/coverage.svg
 
+      - name: Produce version badge
+        run: |
+          pip install anybadge
+          python - <<'PY'
+          import flarchitect, importlib.metadata
+          from anybadge import Badge
+
+          version = getattr(flarchitect, "__version__", importlib.metadata.version("flarchitect"))
+          Badge("version", version).write_badge("version.svg", overwrite=True)
+          PY
+          mkdir -p docs/source/_static
+          cp -f version.svg docs/source/_static/version.svg
+
       - name: Upload test artifacts (coverage + xml)
         uses: actions/upload-artifact@v4
         with:
           name: coverage-artifacts
           path: |
             coverage.svg
+            version.svg
             coverage.xml
             docs/source/_static/coverage.svg
+            docs/source/_static/version.svg
 
   build-docs:
     runs-on: ubuntu-latest
@@ -83,16 +98,17 @@ jobs:
           pip install .[dev]
           pip install sphinx sphinx-rtd-theme
 
-      - name: Download coverage badge from test job
+      - name: Download badges from test job
         uses: actions/download-artifact@v4
         with:
           name: coverage-artifacts
           path: _ci_artifacts
 
-      - name: Place coverage.svg into docs static
+      - name: Place badges into docs static
         run: |
           mkdir -p docs/source/_static
           cp -f _ci_artifacts/docs/source/_static/coverage.svg docs/source/_static/coverage.svg
+          cp -f _ci_artifacts/docs/source/_static/version.svg docs/source/_static/version.svg
 
       - name: Build Sphinx HTML
         run: |

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -26,3 +26,16 @@ jobs:
           coverage xml
           coverage-badge -o coverage.svg
           coverage-badge -o docs/source/_static/coverage.svg
+
+      - name: Produce version badge
+        run: |
+          pip install anybadge
+          python - <<'PY'
+          import flarchitect, importlib.metadata
+          from anybadge import Badge
+
+          version = getattr(flarchitect, "__version__", importlib.metadata.version("flarchitect"))
+          Badge("version", version).write_badge("version.svg", overwrite=True)
+          PY
+          mkdir -p docs/source/_static
+          cp -f version.svg docs/source/_static/version.svg

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Docs](https://github.com/lewis-morris/flarchitect/actions/workflows/docs.yml/badge.svg?branch=master)](https://github.com/lewis-morris/flarchitect/actions/workflows/docs.yml)
 [![Tests](https://github.com/lewis-morris/flarchitect/actions/workflows/run-unit-tests.yml/badge.svg?branch=master)](https://github.com/lewis-morris/flarchitect/actions/workflows/run-unit-tests.yml)
 ![Coverage](https://lewis-morris.github.io/flarchitect/_static/coverage.svg)
+![Version](version.svg)
 
 
 flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQLAlchemy models into a production-ready REST API with almost no boilerplate. It automatically builds CRUD endpoints, generates interactive Redoc documentation and keeps responses consistent so you can focus on your application logic.

--- a/docs/source/_static/version.svg
+++ b/docs/source/_static/version.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="108" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="anybadge_1">
+        <rect width="108" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#anybadge_1)">
+        <path fill="#555" d="M0 0h55v20H0z"/>
+        <path fill="#4c1" d="M55 0h53v20H55z"/>
+        <path fill="url(#b)" d="M0 0h108v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="28.5" y="15" fill="#010101" fill-opacity=".3">version</text>
+        <text x="27.5" y="14">version</text>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="82.5" y="15" fill="#010101" fill-opacity=".3">0.0.9.4</text>
+        <text x="81.5" y="14">0.0.9.4</text>
+    </g>
+</svg>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,6 +35,9 @@ flarchitect
 .. image:: /_static/coverage.svg
    :alt: Coverage Report
 
+.. image:: /_static/version.svg
+   :alt: Package Version
+
 .. image:: https://github.com/lewis-morris/flarchitect/actions/workflows/run-unit-tests.yml/badge.svg?branch=master
    :alt: Tests
 

--- a/version.svg
+++ b/version.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="108" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="anybadge_1">
+        <rect width="108" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#anybadge_1)">
+        <path fill="#555" d="M0 0h55v20H0z"/>
+        <path fill="#4c1" d="M55 0h53v20H55z"/>
+        <path fill="url(#b)" d="M0 0h108v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="28.5" y="15" fill="#010101" fill-opacity=".3">version</text>
+        <text x="27.5" y="14">version</text>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="82.5" y="15" fill="#010101" fill-opacity=".3">0.0.9.4</text>
+        <text x="81.5" y="14">0.0.9.4</text>
+    </g>
+</svg>


### PR DESCRIPTION
## Summary
- add CI steps to generate a version badge from the package version
- embed local version badge in the README and Sphinx index
- commit generated `version.svg` to repo root and docs static assets

## Testing
- `ruff check --fix .github/workflows/docs.yml .github/workflows/run-unit-tests.yml README.md docs/source/index.rst` *(fails: SyntaxError: Starred expression cannot be used here)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cf358af9883228e0b2d4da112f6a9