### PR TITLE
Expose package version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ import datetime
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import os
 import sys
+from importlib.metadata import version as _get_version
 
 sys.path.insert(0, os.path.abspath("../.."))
 
@@ -18,7 +19,7 @@ html_baseurl = "https://lewis-morris.github.io/flarchitect/"
 project = "flarchitect"
 copyright = f"{datetime.datetime.now().year}, arched.dev (Lewis Morris)"
 author = "arched.dev (Lewis Morris)"
-release = "0.1.2"
+release = _get_version("flarchitect")
 
 html_logo = "../logo.png"
 

--- a/flarchitect/__init__.py
+++ b/flarchitect/__init__.py
@@ -7,6 +7,10 @@ This module exposes the primary public interface so users can simply do::
 rather than importing from the internal ``core`` package.
 """
 
+from importlib.metadata import version as _get_version
+
 from .core.architect import Architect
 
-__all__ = ["Architect"]
+__version__ = _get_version("flarchitect")
+
+__all__ = ["Architect", "__version__"]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,8 @@
+from importlib.metadata import version as _get_version
+
+from flarchitect import __version__
+
+
+def test_version_matches_package() -> None:
+    """Ensure the exposed version matches the installed package version."""
+    assert __version__ == _get_version("flarchitect")


### PR DESCRIPTION
## Summary
- expose `__version__` in package init using `importlib.metadata`
- ensure docs release uses installed package version
- test that exposed version matches package metadata

## Testing
- `ruff check flarchitect/__init__.py docs/source/conf.py --fix`
- `ruff check tests/test_version.py --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cf354d07c8322a2fcdecab0b5faab