### PR TITLE
Add tests for demo applications

### DIFF
--- a/demo/authentication/api_key_auth.py
+++ b/demo/authentication/api_key_auth.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from demo.authentication.app_base import BaseConfig, User, create_app, schema
+from demo.authentication.app_base import BaseConfig, User, create_app
 from flarchitect.authentication.user import get_current_user, set_current_user
 
 
@@ -18,13 +18,13 @@ def lookup_user_by_token(token: str) -> User | None:
 class Config(BaseConfig):
     API_AUTHENTICATE_METHOD = ["api_key"]
     API_KEY_AUTH_AND_RETURN_METHOD = staticmethod(lookup_user_by_token)
+    API_USER_MODEL = User
 
 
 app = create_app(Config)
 
 
 @app.get("/profile")
-@schema.route(model=User)
 def profile() -> dict[str, str]:
     """Return the current user's profile."""
 

--- a/demo/authentication/app_base.py
+++ b/demo/authentication/app_base.py
@@ -60,5 +60,7 @@ def create_app(config: type[BaseConfig]) -> Flask:
     app = Flask(__name__)
     app.config.from_object(config)
     db.init_app(app)
-    schema.init_app(app)
+    with app.app_context():
+        db.create_all()
+        schema.init_app(app)
     return app

--- a/demo/authentication/basic_auth.py
+++ b/demo/authentication/basic_auth.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from demo.authentication.app_base import BaseConfig, User, create_app, schema
+from demo.authentication.app_base import BaseConfig, User, create_app
 from flarchitect.authentication.user import get_current_user
 
 
@@ -17,7 +17,6 @@ app = create_app(Config)
 
 
 @app.get("/profile")
-@schema.route(model=User)
 def profile() -> dict[str, str]:
     """Return the current user's profile."""
 

--- a/demo/caching/app.py
+++ b/demo/caching/app.py
@@ -1,0 +1,8 @@
+"""Demo application demonstrating response caching."""
+
+from __future__ import annotations
+
+from demo.model_extension.model import create_app
+
+# Configure a simple in-memory cache with a short timeout.
+app = create_app({"API_CACHE_TYPE": "SimpleCache", "API_CACHE_TIMEOUT": 1})

--- a/demo/validators/app.py
+++ b/demo/validators/app.py
@@ -1,0 +1,8 @@
+"""Demo application showcasing request validation."""
+
+from __future__ import annotations
+
+from demo.model_extension.model import create_app
+
+# Enable automatic validation to enforce field validators defined on models.
+app = create_app({"API_AUTO_VALIDATE": True})

--- a/tests/test_demo_authentication.py
+++ b/tests/test_demo_authentication.py
@@ -1,0 +1,24 @@
+"""Tests for the authentication demo application."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+
+from flask.testing import FlaskClient
+
+from demo.authentication.app_base import User, db
+from demo.authentication.basic_auth import app
+
+
+def test_basic_auth_login() -> None:
+    """User can log in using HTTP Basic credentials."""
+    with app.app_context():
+        db.session.add(User(username="alice", password="wonderland", api_key="unused"))
+        db.session.commit()
+
+    client: FlaskClient = app.test_client()
+    credentials = b64encode(b"alice:wonderland").decode()
+    response = client.post("/auth/login", headers={"Authorization": f"Basic {credentials}"})
+
+    assert response.status_code == 200
+    assert response.get_json()["value"]["username"] == "alice"

--- a/tests/test_demo_caching.py
+++ b/tests/test_demo_caching.py
@@ -1,0 +1,30 @@
+"""Tests for the caching demo application."""
+
+from __future__ import annotations
+
+import time
+
+from flask.testing import FlaskClient
+
+from demo.caching.app import app
+from demo.model_extension.model.extensions import db
+from demo.model_extension.model.models import Author
+
+
+def test_author_endpoint_is_cached() -> None:
+    """Responses are cached for the configured timeout."""
+    client: FlaskClient = app.test_client()
+
+    first = client.get("/api/authors/1").get_json()["value"]["first_name"]
+
+    with app.app_context():
+        author = db.session.get(Author, 1)
+        author.first_name = "Cached"
+        db.session.commit()
+
+    second = client.get("/api/authors/1").get_json()["value"]["first_name"]
+    assert second == first
+
+    time.sleep(1.1)
+    third = client.get("/api/authors/1").get_json()["value"]["first_name"]
+    assert third == "Cached"

--- a/tests/test_demo_validators.py
+++ b/tests/test_demo_validators.py
@@ -1,0 +1,28 @@
+"""Tests for the validators demo application."""
+
+from __future__ import annotations
+
+from flask.testing import FlaskClient
+
+from demo.validators.app import app
+
+VALID_PAYLOAD = {
+    "name": "Test Publisher",
+    "website": "https://example.com",
+    "email": "publisher@example.com",
+    "foundation_year": 1999,
+}
+
+
+def test_author_email_validation() -> None:
+    """Valid data succeeds while invalid email triggers a 400 response."""
+    client: FlaskClient = app.test_client()
+
+    good = client.post("/api/publishers", json=VALID_PAYLOAD)
+    assert good.status_code == 200
+    assert good.get_json()["value"]["email"] == VALID_PAYLOAD["email"]
+
+    bad_payload = dict(VALID_PAYLOAD)
+    bad_payload["email"] = "not-an-email"
+    bad = client.post("/api/publishers", json=bad_payload)
+    assert bad.status_code == 400


### PR DESCRIPTION
## Summary
- fix authentication demo app factory to initialize schema within app context
- add minimal caching and validation demo apps
- test authentication login, request validation and response caching

## Testing
- `ruff check --fix demo/validators/app.py demo/caching/app.py tests/test_demo_authentication.py tests/test_demo_validators.py tests/test_demo_caching.py demo/authentication/app_base.py demo/authentication/api_key_auth.py demo/authentication/basic_auth.py`
- `pytest tests/test_demo_authentication.py tests/test_demo_validators.py tests/test_demo_caching.py`


------
https://chatgpt.com/codex/tasks/task_e_689cf3435ef483229e84cc6402975d1f