### PR TITLE
docs: clarify app context usage

### DIFF
--- a/flarchitect/utils/config_helpers.py
+++ b/flarchitect/utils/config_helpers.py
@@ -60,7 +60,7 @@ def get_config_or_model_meta(
 
     def search_in_flask_config(keys: list[str]) -> Any | None:
         app = current_app
-        with app.app_context():  #
+        with app.app_context():  # Ensure config is accessible outside request contexts
             for key in keys:
                 upper_key = key.upper()
                 prefixed_key = f"API_{upper_key}"


### PR DESCRIPTION
## Summary
- explain why `app.app_context()` is needed when reading Flask config

## Testing
- `ruff check --fix flarchitect/utils/config_helpers.py`
- `ruff format flarchitect/utils/config_helpers.py`
- `pytest` *(fail: tests/test_demo_authentication.py::test_jwt_demo_login_and_profile - assert 500 == 200, tests/test_demo_authentication.py::test_basic_demo_login_and_profile - assert 500 == 200, tests/test_demo_authentication.py::test_api_key_demo_login_and_profile - assert 500 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_689cf9c4ebe08322b3ef58bc284fb464