### PR TITLE
fix: avoid shared mutable defaults in architect and routes

### DIFF
--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -74,7 +74,7 @@ class Architect(AttributeInitializerMixin):
     api_spec: CustomSpec | None = None
     api: Optional["RouteCreator"] = None
     base_dir: str = os.path.dirname(os.path.abspath(__file__))
-    route_spec: list = []
+    route_spec: list[dict[str, Any]] | None = None
     limiter: Limiter
     cache: "Cache | None" = None
 
@@ -91,6 +91,8 @@ class Architect(AttributeInitializerMixin):
             Configures optional integrations such as caching and CORS based on
             application settings.
         """
+        self.route_spec: list[dict[str, Any]] = []
+
         if app is not None:
             self.init_app(app, *args, **kwargs)
             logger.verbosity_level = self.get_config("API_VERBOSITY_LEVEL", 0)
@@ -564,4 +566,8 @@ class Architect(AttributeInitializerMixin):
             route["function"]._decorators = []
 
         route["function"]._decorators.append(self.schema_constructor)
+
+        if self.route_spec is None:
+            self.route_spec = []
+
         self.route_spec.append(route)

--- a/flarchitect/core/routes.py
+++ b/flarchitect/core/routes.py
@@ -223,7 +223,7 @@ def create_route_function(
 
 
 class RouteCreator(AttributeInitializerMixin):
-    created_routes: dict[str, dict[str, Any]] = {}
+    created_routes: dict[str, dict[str, Any]] | None = None
     architect: Architect
     api_full_auto: bool | None = True
     api_base_model: Callable | list[Callable] | None = None
@@ -242,6 +242,7 @@ class RouteCreator(AttributeInitializerMixin):
         """
         super().__init__(*args, **kwargs)
         self.architect = architect
+        self.created_routes: dict[str, dict[str, Any]] = {}
         if self.api_full_auto:
             self.setup_models()
             self.validate()
@@ -892,6 +893,10 @@ class RouteCreator(AttributeInitializerMixin):
         """
         model = kwargs.get("child_model", kwargs.get("model"))
         route_key = kwargs["name"]
+
+        if self.created_routes is None:
+            self.created_routes = {}
+
         self.created_routes[route_key] = {
             "function": route_key,
             "model": model,

--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -363,17 +363,20 @@ def register_schemas(
                 spec.components.schema(schema_name, schema=schema)
 
 
-def register_routes_with_spec(architect: Architect, route_spec: list[dict[str, Any]]):
-    """Registers all flarchitect with the apispec object.
+def register_routes_with_spec(architect: Architect, route_spec: list[dict[str, Any]] | None) -> None:
+    """Register all routes with the :mod:`apispec` object.
 
     Args:
         architect (Architect): The architect object.
-        route_spec (List[Dict[str, Any]]): Routes and schemas to register with
-            the apispec.
+        route_spec (List[Dict[str, Any]] | None): Routes and schemas to
+            register with the apispec. If ``None`` no action is taken.
 
     Returns:
         None
     """
+
+    if not route_spec:
+        return
 
     for route_info in route_spec:
         with architect.app.test_request_context():

--- a/tests/test_mutable_defaults.py
+++ b/tests/test_mutable_defaults.py
@@ -1,0 +1,67 @@
+"""Tests for instance-level initialization of mutable defaults."""
+
+from flask import Flask
+
+from flarchitect import Architect
+from flarchitect.core.routes import RouteCreator
+from flarchitect.specs.generator import register_routes_with_spec
+
+
+def test_architect_route_spec_isolated() -> None:
+    """Route specifications should be unique per :class:`Architect` instance."""
+
+    app1 = Flask("app1")
+    app1.config.update(FULL_AUTO=False, API_CREATE_DOCS=False)
+    with app1.app_context():
+        arch1 = Architect(app1)
+
+    app2 = Flask("app2")
+    app2.config.update(FULL_AUTO=False, API_CREATE_DOCS=False)
+    with app2.app_context():
+        arch2 = Architect(app2)
+
+    def dummy() -> None:  # pragma: no cover - simple placeholder
+        return None
+
+    arch1.set_route({"function": dummy})
+
+    assert len(arch1.route_spec) == 1
+    assert arch2.route_spec == []
+    assert arch1.route_spec is not arch2.route_spec
+
+
+def test_route_creator_created_routes_isolated() -> None:
+    """Created routes should be unique per :class:`RouteCreator` instance."""
+
+    app = Flask(__name__)
+    app.config.update(FULL_AUTO=False, API_CREATE_DOCS=False)
+    with app.app_context():
+        arch = Architect(app)
+
+        rc1 = RouteCreator(architect=arch, app=app, api_full_auto=False)
+        rc2 = RouteCreator(architect=arch, app=app, api_full_auto=False)
+
+    rc1._add_to_created_routes(
+        name="test",
+        method="GET",
+        url="/test",
+        model=None,
+        input_schema=None,
+        output_schema=None,
+    )
+
+    assert "test" in rc1.created_routes
+    assert rc2.created_routes == {}
+    assert rc1.created_routes is not rc2.created_routes
+
+
+def test_register_routes_with_spec_none() -> None:
+    """``register_routes_with_spec`` handles ``None`` gracefully."""
+
+    app = Flask(__name__)
+    app.config.update(FULL_AUTO=False, API_CREATE_DOCS=False)
+    with app.app_context():
+        arch = Architect(app)
+
+        # Should not raise when route_spec is ``None``
+        register_routes_with_spec(arch, None)


### PR DESCRIPTION
## Summary
- avoid shared `route_spec` state by reinitializing per `Architect`
- isolate `RouteCreator.created_routes` per instance
- handle `None` safely in spec registration
- test mutable defaults to prevent regressions

## Testing
- `ruff check --fix tests/test_mutable_defaults.py flarchitect/core/architect.py flarchitect/core/routes.py flarchitect/specs/generator.py`
- `pytest tests/test_mutable_defaults.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf9c4dbd88322bcbc380bd4eb2e28