### PR TITLE
Add type hints and tests for custom HTTP exceptions

### DIFF
--- a/flarchitect/exceptions.py
+++ b/flarchitect/exceptions.py
@@ -18,19 +18,18 @@ class CustomHTTPException(Exception):
     error = None
     reason = None
 
-    def __init__(self, status_code, reason=None):
-        """
-        A custom HTTP exception class
+    def __init__(self, status_code: int, reason: str | None = None) -> None:
+        """A custom HTTP exception class.
 
         Args:
             status_code (int): HTTP status code
-            reason (str): Reason for the HTTP status code
+            reason (str | None): Reason for the HTTP status code
         """
         self.status_code = status_code
         self.error = HTTPStatus(status_code).phrase  # Fetch the standard HTTP status phrase
         self.reason = reason or self.error  # Use the reason if provided, otherwise use the standard HTTP status phrase
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, int | str | None]:
         return {
             "status_code": self.status_code,
             "status_text": self.error,
@@ -82,5 +81,5 @@ def _handle_exception(error: str, status_code: int, error_name: str | None = Non
         errors={
             "error": error,
             "reason": error_name,
-        },  # changed this in an attempt to make errors more uniform ##[{"status_text": error_name or "Error", "error": error}]
+        },  # Structured error payload for consistent responses
     )

--- a/tests/test_custom_http_exception.py
+++ b/tests/test_custom_http_exception.py
@@ -1,0 +1,24 @@
+"""Tests for CustomHTTPException and related helpers."""
+
+from flask import Flask
+
+from flarchitect.exceptions import CustomHTTPException, _handle_exception
+
+
+def test_custom_http_exception_to_dict() -> None:
+    exc = CustomHTTPException(400, "Invalid input")
+    assert exc.to_dict() == {
+        "status_code": 400,
+        "status_text": "Bad Request",
+        "reason": "Invalid input",
+    }
+
+
+def test_handle_exception_returns_response() -> None:
+    app = Flask(__name__)
+    with app.test_request_context():
+        response = _handle_exception("Unexpected", 500, error_name="Server Error", print_exc=False)
+        data = response.get_json()
+        assert response.status_code == 500
+        assert data["errors"] == {"error": "Unexpected", "reason": "Server Error"}
+        assert data["status_code"] == 500


### PR DESCRIPTION
## Summary
- add explicit type hints to `CustomHTTPException` and its `to_dict` helper
- clarify structured error payload handling in `_handle_exception`
- add tests verifying exception dict output and response handling

## Testing
- `ruff format tests/test_exceptions.py tests/test_custom_http_exception.py`
- `ruff check .`
- `pytest tests/test_custom_http_exception.py`
- `pytest` *(fails: KeyboardInterrupt due to excessive warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689cfabc87c083228153e42ca67e8ff1