### PR TITLE
docs: reorganize nested model and dump types

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -202,9 +202,9 @@
         - Ignores attributes prefixed with ``_`` during serialization to keep internal fields hidden. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
     * - ``API_SERIALIZATION_TYPE``
 
-          :bdg-secondary:`Optional` 
+          :bdg-secondary:`Optional`
 
-        - Output format for serialized data, such as ``json`` or ``xml``. Determines how responses are rendered. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+        - Output format for serialized data. Options include ``url`` (default), ``json``, ``dynamic`` and ``hybrid``. Determines how responses are rendered. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
     * - ``API_SERIALIZATION_DEPTH``
 
           :bdg-secondary:`Optional` 

--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -143,6 +143,33 @@ Disabling all metadata::
         "data": [...]
     }
 
+Nested model creation
+---------------------
+
+Nested writes are disabled by default. Enable them globally with
+``API_ALLOW_NESTED_WRITES = True`` or per model via ``Meta.allow_nested_writes``.
+Once enabled, ``AutoSchema`` can deserialize nested relationship data during
+POST or PUT requests. Include related objects under the relationship name in
+your payload::
+
+    {
+        "title": "My Book",
+        "isbn": "12345",
+        "publication_date": "2024-01-01",
+        "author_id": 1,
+        "author": {
+            "first_name": "John",
+            "last_name": "Doe",
+            "biography": "Bio",
+            "date_of_birth": "1980-01-01",
+            "nationality": "US"
+        }
+    }
+
+The nested ``author`` object is deserialized into an ``Author`` instance while
+responses continue to use the configured serialization type (URL, JSON, or
+dynamic).
+
 CORS
 ----
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -21,29 +21,23 @@ Example::
 
 That's all that's required to make the model available through the generated API.
 
-Nested model creation
----------------------
+Dump types
+----------
 
-Nested writes are disabled by default. Enable them globally with
-``API_ALLOW_NESTED_WRITES = True`` or per model via ``Meta.allow_nested_writes``.
-Once enabled, ``AutoSchema`` can deserialize nested relationship data during
-POST or PUT requests. Include related objects under the relationship name in
-your payload::
+``flarchitect`` can serialize model responses in different formats, controlled
+by ``API_SERIALIZATION_TYPE`` or ``Meta.serialization_type``. Supported dump
+types are:
 
-    {
-        "title": "My Book",
-        "isbn": "12345",
-        "publication_date": "2024-01-01",
-        "author_id": 1,
-        "author": {
-            "first_name": "John",
-            "last_name": "Doe",
-            "biography": "Bio",
-            "date_of_birth": "1980-01-01",
-            "nationality": "US"
-        }
-    }
+* ``url`` (default) – represent related objects only by their URL links.
+* ``json`` – embed related objects as JSON objects.
+* ``dynamic`` – choose between ``url`` and ``json`` using the ``dump`` query
+  parameter.
+* ``hybrid`` – include both URL links and embedded JSON for related objects.
 
-The nested ``author`` object is deserialized into an ``Author`` instance while
-responses continue to use the configured serialization type (URL, JSON, or
-dynamic).
+Example::
+
+    class Config:
+        API_SERIALIZATION_TYPE = "json"
+
+Clients can override ``dynamic`` dumps per request with
+``?dump=url`` or ``?dump=json``.


### PR DESCRIPTION
## Summary
- move nested model creation guidance to advanced configuration docs
- document available dump types in models guide
- clarify API_SERIALIZATION_TYPE options in configuration table

## Testing
- `rstcheck docs/source/models.rst docs/source/advanced_configuration.rst docs/source/_configuration_table.rst` *(fails: Unknown interpreted text role "bdg" and other warnings)*
- `make -C docs html` *(fails: PackageNotFoundError: No package metadata was found for flarchitect)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689cfbdf0df083229d4e6aec321171e5