### PR TITLE
feat: auto resolve db sessions

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -16,7 +16,9 @@ Install the package via pip.
 Define your models
 ----------------------------------------
 
-Create a base class that returns a database session and define any models you want to expose.
+Define your models using SQLAlchemy. ``flarchitect`` automatically resolves
+the active database session, whether you're using Flask-SQLAlchemy or plain
+SQLAlchemy, so no special ``get_session`` method is required.
 
 .. code:: python
 
@@ -24,8 +26,7 @@ Create a base class that returns a database session and define any models you wa
     from sqlalchemy.orm import DeclarativeBase
 
     class BaseModel(DeclarativeBase):
-        def get_session(*args):
-            return db.session
+        pass
 
     db = SQLAlchemy(model_class=BaseModel)
 
@@ -36,7 +37,9 @@ Create a base class that returns a database session and define any models you wa
             tag = "Author"
             tag_group = "People/Companies"
 
-This setup gives **flarchitect** access to your session and metadata so it can generate CRUD endpoints.
+This setup gives **flarchitect** access to your models. The library automatically
+locates the active SQLAlchemy session. For non-Flask setups, a custom session
+resolver can be supplied via ``API_SESSION_GETTER`` in the Flask config.
 
 Configure Flask
 ----------------------------------------

--- a/docs/source/soft_delete.rst
+++ b/docs/source/soft_delete.rst
@@ -38,9 +38,6 @@ Add a boolean column to your base model so every table can inherit the flag:
        updated: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
        deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
-       def get_session(*args):
-           return db.session
-
    db = SQLAlchemy(model_class=BaseModel)
 
    class Book(db.Model):

--- a/flarchitect/authentication/jwt.py
+++ b/flarchitect/authentication/jwt.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import NoResultFound
 from flarchitect.database.utils import get_primary_keys
 from flarchitect.exceptions import CustomHTTPException
 from flarchitect.utils.config_helpers import get_config_or_model_meta
+from flarchitect.utils.session import get_session
 
 # Secret keys (keep them secure)
 
@@ -162,7 +163,7 @@ def refresh_access_token(refresh_token: str) -> tuple[str, Any]:
     # Query the user by lookup_field and pk
     try:
         user = (
-            usr_model_class.get_session()
+            get_session(usr_model_class)
             .query(usr_model_class)
             .filter(
                 getattr(usr_model_class, lookup_field) == lookup_value,
@@ -209,7 +210,7 @@ def get_user_from_token(token: str, secret_key: str | None = None) -> Any:
     # Query the user by primary key or lookup field (like username)
     try:
         user = (
-            usr_model_class.get_session()
+            get_session(usr_model_class)
             .query(usr_model_class)
             .filter(
                 getattr(usr_model_class, lookup_field) == payload[lookup_field],

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -30,6 +30,7 @@ from flarchitect.utils.general import (
     check_rate_services,
     validate_flask_limiter_rate_limit_string,
 )
+from flarchitect.utils.session import get_session
 
 FLASK_APP_NAME = "flarchitect"
 
@@ -415,8 +416,9 @@ class Architect(AttributeInitializerMixin):
 
         query = getattr(user_model, "query", None)
         if query is None:
-            session = getattr(user_model, "get_session", lambda: None)()
-            if session is None:
+            try:
+                session = get_session(user_model)
+            except Exception:
                 return False
             query = session.query(user_model)
 

--- a/flarchitect/utils/__init__.py
+++ b/flarchitect/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for flarchitect."""
+
+from .session import get_session
+
+__all__ = ["get_session"]

--- a/flarchitect/utils/session.py
+++ b/flarchitect/utils/session.py
@@ -1,0 +1,86 @@
+"""Utilities for resolving SQLAlchemy sessions.
+
+This module provides :func:`get_session`, a helper that tries to
+locate the active :class:`sqlalchemy.orm.Session` object used by the
+application. It supports both ``Flask-SQLAlchemy`` and plain SQLAlchemy
+setups so that models do not need to implement their own
+``get_session`` method.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from flask import current_app
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+from flarchitect.utils.config_helpers import get_config_or_model_meta
+
+
+def get_session(model: type[DeclarativeBase] | None = None) -> Session:
+    """Return the active SQLAlchemy :class:`~sqlalchemy.orm.Session`.
+
+    The session is resolved using the following strategies in order:
+
+    1. A custom ``API_SESSION_GETTER`` callable supplied via configuration.
+    2. ``Flask-SQLAlchemy``'s ``db.session`` if running inside a Flask
+       application.
+    3. A ``query`` attribute on the provided model.
+    4. A legacy ``get_session`` method on the model.
+    5. Creating a session from the model's bound engine.
+
+    Args:
+        model: Optional SQLAlchemy declarative model used when searching
+            for a session.
+
+    Returns:
+        The resolved :class:`~sqlalchemy.orm.Session` instance.
+
+    Raises:
+        RuntimeError: If no session can be determined.
+    """
+
+    # 1. Configurable getter from Flask config or model meta
+    try:
+        custom_getter: Callable[[], Session] | None = get_config_or_model_meta("API_SESSION_GETTER", model=model, default=None)
+        if callable(custom_getter):
+            session = custom_getter()
+            if session is not None:
+                return session
+    except Exception:
+        pass
+
+    # 2. Flask-SQLAlchemy global session
+    try:  # pragma: no cover - only executed when Flask context exists
+        ext = current_app.extensions.get("sqlalchemy")  # type: ignore[attr-defined]
+        if ext is not None:
+            session = getattr(ext, "session", None)
+            if session is not None:
+                return session
+    except Exception:
+        pass
+
+    if model is not None:
+        # 3. SQLAlchemy model bound session via query attribute
+        query = getattr(model, "query", None)
+        session = getattr(query, "session", None)
+        if session is not None:
+            return session
+
+        # 4. Legacy ``get_session`` method on the model
+        legacy_getter = getattr(model, "get_session", None)
+        if callable(legacy_getter):
+            session = legacy_getter()
+            if session is not None:
+                return session
+
+        # 5. Create a session from the model's bound engine
+        engine = getattr(getattr(model, "__table__", None), "metadata", None)
+        engine = getattr(engine, "bind", None)
+        if engine is None:
+            engine = getattr(getattr(model, "metadata", None), "bind", None)
+        if engine is not None:
+            SessionMaker = sessionmaker(bind=engine)
+            return SessionMaker()
+
+    raise RuntimeError("Unable to determine database session; configure API_SESSION_GETTER or bind an engine.")

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -39,10 +39,6 @@ class User(db.Model):
     def check_api_key(self, key: str) -> bool:
         return check_password_hash(self.api_key_hash, key)
 
-    @staticmethod
-    def get_session():
-        return db.session
-
 
 class UsernameSchema(Schema):
     """Schema for serializing responses containing a username."""
@@ -238,11 +234,11 @@ def client_custom() -> Generator[FlaskClient, None, None]:
 def assert_unauthorized(resp: Response) -> None:
     """Assert unauthorized response and cleared user context.
 
-    Args:<<<<<<< arched/add-test-cases-for-authentication-errors
-329
- 
+        Args:<<<<<<< arched/add-test-cases-for-authentication-errors
+    329
 
-        resp (Response): Flask response object to verify.
+
+            resp (Response): Flask response object to verify.
     """
     assert resp.status_code == 401
     assert get_current_user() is None

--- a/tests/test_session_helper.py
+++ b/tests/test_session_helper.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Integer, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column
+
+from flarchitect.utils.session import get_session
+
+
+def test_get_session_flask_sqlalchemy() -> None:
+    """Session resolves automatically from Flask-SQLAlchemy."""
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+    )
+    db = SQLAlchemy()
+
+    class User(db.Model):
+        id = db.Column(db.Integer, primary_key=True)
+
+    db.init_app(app)
+    with app.app_context():
+        assert get_session(User) is db.session
+
+
+def test_get_session_plain_sqlalchemy() -> None:
+    """Session derives from a model's bound engine without Flask."""
+
+    class Base(DeclarativeBase):
+        pass
+
+    class Item(Base):
+        __tablename__ = "items"
+        id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.bind = engine
+    Base.metadata.create_all(engine)
+
+    session = get_session(Item)
+    try:
+        assert isinstance(session, Session)
+    finally:
+        session.close()

--- a/tests/test_soft_delete.py
+++ b/tests/test_soft_delete.py
@@ -22,11 +22,6 @@ class BaseModel(DeclarativeBase):
     updated: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
     deleted: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
-    @staticmethod
-    def get_session(*args):  # type: ignore[override]
-        """Return the active database session."""
-        return db.session
-
 
 db = SQLAlchemy(model_class=BaseModel)
 


### PR DESCRIPTION
## Summary
- add `get_session` utility to automatically locate SQLAlchemy sessions
- use new session helper across routes and authentication
- document automatic session discovery and update tests

## Testing
- `ruff format flarchitect/utils/session.py flarchitect/utils/__init__.py flarchitect/core/architect.py flarchitect/core/routes.py flarchitect/authentication/jwt.py tests/test_authentication.py tests/test_soft_delete.py tests/test_session_helper.py`
- `ruff check --fix flarchitect/utils/session.py flarchitect/utils/__init__.py flarchitect/core/architect.py flarchitect/core/routes.py flarchitect/authentication/jwt.py tests/test_authentication.py tests/test_soft_delete.py tests/test_session_helper.py`
- `pytest tests/test_session_helper.py tests/test_authentication.py tests/test_soft_delete.py`
- `sphinx-build -b html docs/source docs/build/html`

------
https://chatgpt.com/codex/tasks/task_e_689cfb4a5174832288e382e6f7579267