### PR TITLE
Fix mutable defaults in CustomSpec

### DIFF
--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -45,13 +45,13 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
     app: Flask
     architect: Architect  # The architect object
 
-    spec_groups: dict[str, list[dict[str, str | list[str]]]] = {"x-tagGroups": []}
+    spec_groups: dict[str, list[dict[str, str | list[str]]]] | None = None
     api_title: str | None = ""
     api_version: str | None = ""
     api_description: str | None = None
     api_logo_url: str | None = None
     api_logo_background: str | None = None
-    api_keywords: list[str] | None = []
+    api_keywords: list[str] | None = None
     create_docs: bool | None = True
     documentation_url_prefix: str | None = "/"
     documentation_url: str | None = "/docs"
@@ -67,6 +67,9 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
         """
         self.app = app
         self.architect = architect
+        # initialize per-instance containers to avoid shared mutable defaults
+        self.spec_groups: dict[str, list[dict[str, str | list[str]]]] = {"x-tagGroups": []}
+        self.api_keywords: list[str] = []
         super().__init__(*args, **self._prepare_api_spec_data(**kwargs))
 
         if self._should_create_docs():
@@ -81,7 +84,8 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
             dict: The API specification as a dictionary.
         """
         spec_dict = super().to_dict()
-        spec_dict.update(self.spec_groups)
+        if self.spec_groups:
+            spec_dict.update(self.spec_groups)
         return spec_dict
 
     def _prepare_api_spec_data(self, **kwargs) -> dict:
@@ -212,12 +216,17 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
         Example:
             >>> spec.set_xtags_group("Users", "Authentication")
         """
-        for group in self.spec_groups["x-tagGroups"]:
+        if self.spec_groups is None:
+            self.spec_groups = {"x-tagGroups": []}
+
+        tag_groups = self.spec_groups.setdefault("x-tagGroups", [])
+
+        for group in tag_groups:
             if group["name"] == group_name:
                 if tag_name not in group["tags"]:
                     group["tags"].append(tag_name)
                 return
-        self.spec_groups["x-tagGroups"].append({"name": group_name, "tags": [tag_name]})
+        tag_groups.append({"name": group_name, "tags": [tag_name]})
 
     def _create_specification_blueprint(self) -> None:
         """Sets up the blueprint to serve the API specification and documentation."""

--- a/tests/test_custom_spec_defaults.py
+++ b/tests/test_custom_spec_defaults.py
@@ -1,0 +1,59 @@
+"""Tests for ensuring ``CustomSpec`` uses instance-specific containers."""
+
+from flask import Flask
+
+from flarchitect.specs.generator import CustomSpec
+
+
+class DummyArchitect:
+    """Minimal architect stub for CustomSpec tests."""
+
+    def __init__(self, app: Flask) -> None:
+        self.app = app
+        self.route_spec: list[dict] = []
+
+    def get_templates_path(self) -> str:
+        """Return dummy templates path required by CustomSpec."""
+        return ""
+
+
+def _create_spec() -> CustomSpec:
+    """Create a ``CustomSpec`` with docs generation disabled."""
+    app = Flask(__name__)
+    app.config["API_CREATE_DOCS"] = False
+    app.config["API_DESCRIPTION"] = "desc"
+    architect = DummyArchitect(app)
+    with app.app_context():
+        return CustomSpec(app, architect)
+
+
+def test_spec_groups_are_instance_specific() -> None:
+    """Each ``CustomSpec`` should maintain its own ``spec_groups``."""
+    spec_one = _create_spec()
+    spec_two = _create_spec()
+
+    spec_one.set_xtags_group("tag1", "group1")
+
+    assert spec_one.spec_groups["x-tagGroups"] == [{"name": "group1", "tags": ["tag1"]}]
+    assert spec_two.spec_groups == {"x-tagGroups": []}
+
+
+def test_api_keywords_are_instance_specific() -> None:
+    """Each ``CustomSpec`` should maintain its own ``api_keywords`` list."""
+    spec_one = _create_spec()
+    spec_two = _create_spec()
+
+    spec_one.api_keywords.append("keyword")
+
+    assert spec_one.api_keywords == ["keyword"]
+    assert spec_two.api_keywords == []
+
+
+def test_to_dict_handles_none_spec_groups() -> None:
+    """``to_dict`` should not fail when ``spec_groups`` is ``None``."""
+    spec = _create_spec()
+    spec.spec_groups = None
+
+    spec_dict = spec.to_dict()
+
+    assert "x-tagGroups" not in spec_dict


### PR DESCRIPTION
## Summary
- avoid shared mutable defaults for spec groups and API keywords
- guard usage of spec groups when undefined
- add tests for per-instance spec structures

## Testing
- `ruff check flarchitect tests/test_custom_spec_defaults.py --fix`
- `ruff format flarchitect tests/test_custom_spec_defaults.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cfad9c0848322acd7f21768154401