### PR TITLE
Fix demo authentication tests and error handling

### DIFF
--- a/flarchitect/core/routes.py
+++ b/flarchitect/core/routes.py
@@ -402,13 +402,13 @@ class RouteCreator(AttributeInitializerMixin):
         def basic_login() -> dict[str, Any]:
             auth_header = request.headers.get("Authorization", "")
             if not auth_header.startswith("Basic "):
-                raise CustomHTTPException(401, "Invalid credentials")
+                return create_response(status=401, errors={"error": "Invalid credentials"})
 
             try:
                 encoded = auth_header.split(" ", 1)[1]
                 username, password = base64.b64decode(encoded).decode("utf-8").split(":", 1)
-            except (ValueError, binascii.Error, UnicodeDecodeError) as exc:  # pragma: no cover - bad header
-                raise CustomHTTPException(401, "Invalid credentials") from exc
+            except (ValueError, binascii.Error, UnicodeDecodeError):  # pragma: no cover - bad header
+                return create_response(status=401, errors={"error": "Invalid credentials"})
 
             lookup_field = get_config_or_model_meta("API_USER_LOOKUP_FIELD", model=user, default=None)
             check_method = get_config_or_model_meta("API_CREDENTIAL_CHECK_METHOD", model=user, default=None)
@@ -418,7 +418,7 @@ class RouteCreator(AttributeInitializerMixin):
                 pk, lookup = get_pk_and_lookups()
                 return create_response({"user_pk": getattr(usr, pk), lookup: getattr(usr, lookup)})
 
-            raise CustomHTTPException(401, "Invalid credentials")
+            return create_response(status=401, errors={"error": "Invalid credentials"})
 
     def _make_api_key_auth_routes(self, user: Callable) -> None:
         """Create API key authentication login route.
@@ -433,7 +433,7 @@ class RouteCreator(AttributeInitializerMixin):
             header = request.headers.get("Authorization", "")
             scheme, _, token = header.partition(" ")
             if scheme.lower() != "api-key" or not token:
-                raise CustomHTTPException(401, "Invalid credentials")
+                return create_response(status=401, errors={"error": "Invalid credentials"})
 
             custom_method = get_config_or_model_meta("API_KEY_AUTH_AND_RETURN_METHOD", model=user, default=None)
             if callable(custom_method):
@@ -461,7 +461,7 @@ class RouteCreator(AttributeInitializerMixin):
                 pk, lookup = get_pk_and_lookups()
                 return create_response({"user_pk": getattr(usr, pk), lookup: getattr(usr, lookup)})
 
-            raise CustomHTTPException(401, "Invalid credentials")
+            return create_response(status=401, errors={"error": "Invalid credentials"})
 
     def _make_jwt_auth_routes(self, user: Callable):
         """Create JWT authentication routes."""

--- a/flarchitect/schemas/auth.py
+++ b/flarchitect/schemas/auth.py
@@ -1,4 +1,6 @@
 # Schema for loading login data (username and password)
+from typing import Any
+
 from marshmallow import Schema, ValidationError, fields, validates
 
 
@@ -8,11 +10,12 @@ class LoginSchema(Schema):
 
     # Optional: Add custom validations for username or password, if needed
     @validates("username")
-    def validate_username(self, value: str) -> None:
+    def validate_username(self, value: str, **_: Any) -> None:
         """Ensure the username is present and sufficiently long.
 
         Args:
             value: The username provided by the user.
+            _ (Any): Additional keyword arguments supplied by Marshmallow.
 
         Raises:
             ValidationError: If ``value`` is empty or shorter than three characters.
@@ -24,11 +27,12 @@ class LoginSchema(Schema):
             raise ValidationError("Username must be at least 3 characters long.")
 
     @validates("password")
-    def validate_password(self, value: str) -> None:
+    def validate_password(self, value: str, **_: Any) -> None:
         """Ensure the password meets minimum requirements.
 
         Args:
             value: The password supplied by the user.
+            _ (Any): Additional keyword arguments supplied by Marshmallow.
 
         Raises:
             ValidationError: If ``value`` is empty or shorter than six characters.

--- a/tests/test_demo_authentication.py
+++ b/tests/test_demo_authentication.py
@@ -1,4 +1,3 @@
-
 """Integration tests for demo authentication strategies."""
 
 from __future__ import annotations
@@ -7,9 +6,16 @@ import base64
 from collections.abc import Callable
 
 from flask.testing import FlaskClient
+from marshmallow import Schema, fields
 
-from demo.authentication.app_base import BaseConfig, User, create_app, db
+from demo.authentication.app_base import BaseConfig, User, create_app, db, schema
 from flarchitect.authentication.user import get_current_user, set_current_user
+
+
+class ProfileSchema(Schema):
+    """Minimal schema exposing the authenticated user's username."""
+
+    username = fields.String(required=True)
 
 
 def _prepare_app(config: type[BaseConfig], setup: Callable[[FlaskClient], None]) -> FlaskClient:
@@ -18,7 +24,10 @@ def _prepare_app(config: type[BaseConfig], setup: Callable[[FlaskClient], None])
     app = create_app(config)
 
     @app.get("/profile")
-    def profile() -> dict[str, str]:  # type: ignore[unused-variable]
+    @schema.schema_constructor(output_schema=ProfileSchema, auth=True)
+    def profile() -> dict[str, str]:
+        """Return the authenticated user's profile."""
+
         user = get_current_user()
         return {"username": user.username}
 
@@ -61,9 +70,7 @@ def test_jwt_demo_login_and_profile() -> None:
     assert profile.status_code == 200
     assert profile.get_json()["value"]["username"] == "alice"
 
-    bad_login = client.post(
-        "/auth/login", json={"username": "alice", "password": "bad"}
-    )
+    bad_login = client.post("/auth/login", json={"username": "alice", "password": "badpwd"})
     assert bad_login.status_code == 401
 
 
@@ -90,10 +97,8 @@ def test_basic_demo_login_and_profile() -> None:
     assert profile.status_code == 200
     assert profile.get_json()["value"]["username"] == "bob"
 
-    bad_creds = base64.b64encode(b"bob:wrong").decode("utf-8")
-    bad_login = client.post(
-        "/auth/login", headers={"Authorization": f"Basic {bad_creds}"}
-    )
+    bad_creds = base64.b64encode(b"bob:wrongp").decode("utf-8")
+    bad_login = client.post("/auth/login", headers={"Authorization": f"Basic {bad_creds}"})
     assert bad_login.status_code == 401
 
 
@@ -110,6 +115,7 @@ def test_api_key_demo_login_and_profile() -> None:
         API_AUTHENTICATE_METHOD = ["api_key"]
         API_USER_MODEL = User
         API_KEY_AUTH_AND_RETURN_METHOD = staticmethod(lookup_user_by_token)
+        API_USER_LOOKUP_FIELD = "username"
 
     def seed(_: FlaskClient) -> None:
         user = User(username="carol", password="pw", api_key="secret")
@@ -125,7 +131,5 @@ def test_api_key_demo_login_and_profile() -> None:
     assert profile.status_code == 200
     assert profile.get_json()["value"]["username"] == "carol"
 
-    bad_login = client.post(
-        "/auth/login", headers={"Authorization": "Api-Key bad"}
-    )
+    bad_login = client.post("/auth/login", headers={"Authorization": "Api-Key bad"})
     assert bad_login.status_code == 401


### PR DESCRIPTION
## Summary
- ensure `LoginSchema` validators accept Marshmallow keyword arguments
- enforce auth on the demo `profile` route with a schema and proper config
- return standardized 401 responses for invalid Basic and API key logins

## Testing
- `ruff check --fix flarchitect/core/routes.py flarchitect/schemas/auth.py tests/test_demo_authentication.py`
- `ruff format flarchitect/core/routes.py flarchitect/schemas/auth.py tests/test_demo_authentication.py`
- `pytest tests/test_demo_authentication.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d01b9e65c8322befac41df5417519