### PR TITLE
ci: publish to PyPI on version change

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,56 @@
+name: Publish to PyPI
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Detect version change
+        id: version
+        run: |
+          NEW_VERSION=$(python - <<'PY'
+import pathlib, tomllib
+print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])
+PY
+)
+          OLD_VERSION=$(git show HEAD^:pyproject.toml 2>/dev/null | python - <<'PY'
+import sys, tomllib
+print(tomllib.loads(sys.stdin.read())['project']['version'])
+PY
+ || echo '')
+          echo "new=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "old=$OLD_VERSION" >> $GITHUB_OUTPUT
+          if [ "$NEW_VERSION" != "$OLD_VERSION" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install build tools
+        if: steps.version.outputs.changed == 'true'
+        run: python -m pip install build
+
+      - name: Build
+        if: steps.version.outputs.changed == 'true'
+        run: python -m build
+
+      - name: Publish
+        if: steps.version.outputs.changed == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -118,6 +118,17 @@ ruff --fix .
 pytest
 ```
 
+## Versioning & Releases
+
+The package version is defined in `pyproject.toml` and exposed as `flarchitect.__version__`. A GitHub Actions workflow automatically publishes to PyPI when the version changes on `master`.
+
+To publish a new release:
+
+1. Update the `version` field in `pyproject.toml` (for example with `hatch version patch`).
+2. Commit and push to `master`.
+
+Ensure the repository has a `PYPI_API_TOKEN` secret with an API token from PyPI.
+
 ## License
 
 Distributed under the MIT License. See [LICENCE](LICENCE) for details.


### PR DESCRIPTION
## Summary
- add GitHub workflow to build and publish to PyPI when `pyproject.toml` version changes on `master`
- document versioning and release process

## Testing
- `ruff check --fix .` *(fails: flarchitect/core/architect.py:438:27 F821 Undefined name `get_session`)*
- `pytest` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689d06205ce0832281fb1b5a22fd15ad