### PR TITLE
Gracefully handle missing route specs

### DIFF
--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -372,17 +372,20 @@ def register_schemas(
                 spec.components.schema(schema_name, schema=schema)
 
 
-def register_routes_with_spec(architect: Architect, route_spec: list[dict[str, Any]]):
-    """Registers all flarchitect with the apispec object.
+def register_routes_with_spec(architect: Architect, route_spec: list[dict[str, Any]] | None) -> None:
+    """Register routes and schemas with the API spec.
 
     Args:
-        architect (Architect): The architect object.
-        route_spec (List[Dict[str, Any]]): Routes and schemas to register with
-            the apispec.
+        architect: The :class:`~flarchitect.Architect` instance.
+        route_spec: Routes and schemas to register with the apispec. ``None`` is
+            accepted to gracefully skip registration.
 
     Returns:
         None
     """
+
+    if not route_spec:
+        return
 
     for route_info in route_spec:
         with architect.app.test_request_context():

--- a/tests/test_demo_authentication.py
+++ b/tests/test_demo_authentication.py
@@ -68,11 +68,10 @@ def test_jwt_demo_login_and_profile() -> None:
         headers={"Authorization": f"Bearer {tokens['access_token']}"},
     )
     assert profile.status_code == 200
-    assert profile.get_json()["username"] == "alice"
+    profile_json = profile.get_json()
+    assert profile_json["value"]["username"] == "alice"
 
-    bad_login = client.post(
-        "/auth/login", json={"username": "alice", "password": "badpass"}
-    )
+    bad_login = client.post("/auth/login", json={"username": "alice", "password": "badpass"})
     assert bad_login.status_code == 401
 
 
@@ -97,13 +96,11 @@ def test_basic_demo_login_and_profile() -> None:
 
     profile = client.get("/profile", headers={"Authorization": f"Basic {creds}"})
     assert profile.status_code == 200
-    assert profile.get_json()["username"] == "bob"
-
+    profile_json = profile.get_json()
+    assert profile_json["value"]["username"] == "bob"
 
     bad_creds = base64.b64encode(b"bob:wrongpwd").decode("utf-8")
-    bad_login = client.post(
-        "/auth/login", headers={"Authorization": f"Basic {bad_creds}"}
-    )
+    bad_login = client.post("/auth/login", headers={"Authorization": f"Basic {bad_creds}"})
     assert bad_login.status_code == 401
 
 
@@ -134,7 +131,8 @@ def test_api_key_demo_login_and_profile() -> None:
 
     profile = client.get("/profile", headers=headers)
     assert profile.status_code == 200
-    assert profile.get_json()["username"] == "carol"
+    profile_json = profile.get_json()
+    assert profile_json["value"]["username"] == "carol"
 
     bad_login = client.post("/auth/login", headers={"Authorization": "Api-Key bad"})
     assert bad_login.status_code == 401


### PR DESCRIPTION
## Summary
- avoid iterating over `None` route specs when registering with the API spec
- align demo authentication tests with response structure returned by `create_response`

## Testing
- `ruff check --fix flarchitect/specs/generator.py tests/test_demo_authentication.py`
- `ruff format flarchitect/specs/generator.py tests/test_demo_authentication.py`
- `pytest tests/test_mutable_defaults.py::test_register_routes_with_spec_none tests/test_demo_authentication.py::test_jwt_demo_login_and_profile tests/test_demo_authentication.py::test_basic_demo_login_and_profile tests/test_demo_authentication.py::test_api_key_demo_login_and_profile -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d05a1fb0c8322bca1fae51e6bd1db