### PR TITLE
docs: rename callbacks to extensions

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -440,5 +440,5 @@ return callbacks in configuration or on a model's ``Meta`` class.
     class Config:
         API_POST_SETUP_CALLBACK = ensure_admin
 
-For more examples see the :doc:`callbacks` page.
+For more examples see the :doc:`extensions` page.
 

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -1,4 +1,4 @@
-Callbacks
+Extensions
 =========================================
 
 Callbacks let you hook into the request lifecycle to run custom logic around

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,7 +18,7 @@ flarchitect
    models
    validation
    authentication
-   callbacks
+   extensions
    configuration
    openapi
    soft_delete


### PR DESCRIPTION
## Summary
- rename callbacks documentation to extensions
- update references to new extensions page

## Testing
- `pre-commit run --files docs/source/extensions.rst docs/source/index.rst docs/source/advanced_configuration.rst` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest` *(fails: 34 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689d07404e5c8322883a396b90c6079c