### PR TITLE
docs: consolidate demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,8 @@ pytest
 ## Documentation & help
 
 - Browse the [full documentation](https://lewis-morris.github.io/flarchitect/) for tutorials and API reference.
-- Explore runnable examples in the [demo](https://github.com/lewis-morris/flarchitect/tree/master/demo) directory.
-- Authentication demos: [JWT](demo/authentication/jwt_auth.py), [Basic](demo/authentication/basic_auth.py) and [API key](demo/authentication/api_key_auth.py) snippets showcase the built-in strategies.
 - Explore runnable examples in the [demo](https://github.com/lewis-morris/flarchitect/tree/master/demo) directory, including a [validators example](demo/validators/README.md) showcasing email and URL validation.
+- Authentication demos: [JWT](demo/authentication/jwt_auth.py), [Basic](demo/authentication/basic_auth.py) and [API key](demo/authentication/api_key_auth.py) snippets showcase the built-in strategies.
 - Questions? Join the [GitHub discussions](https://github.com/lewis-morris/flarchitect/discussions) or open an [issue](https://github.com/lewis-morris/flarchitect/issues).
 - See the [changelog](CHANGES.rst) for release history.
 

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -30,9 +30,8 @@ from flarchitect.utils.general import (
     check_rate_services,
     validate_flask_limiter_rate_limit_string,
 )
-
 from flarchitect.utils.response_helpers import create_response
-
+from flarchitect.utils.session import get_session
 
 FLASK_APP_NAME = "flarchitect"
 

--- a/flarchitect/schemas/auth.py
+++ b/flarchitect/schemas/auth.py
@@ -1,5 +1,4 @@
 # Schema for loading login data (username and password)
-from typing import Any
 
 from marshmallow import Schema, ValidationError, fields, validates
 
@@ -15,7 +14,7 @@ class LoginSchema(Schema):
 
         Args:
             value: The username provided by the user.
-            _ (Any): Additional keyword arguments supplied by Marshmallow.
+            _: Additional keyword arguments supplied by Marshmallow.
 
         Raises:
             ValidationError: If ``value`` is empty or shorter than three characters.
@@ -32,7 +31,7 @@ class LoginSchema(Schema):
 
         Args:
             value: The password supplied by the user.
-            _ (Any): Additional keyword arguments supplied by Marshmallow.
+            _: Additional keyword arguments supplied by Marshmallow.
 
         Raises:
             ValidationError: If ``value`` is empty or shorter than six characters.


### PR DESCRIPTION
## Summary
- merge duplicate demo bullets in README and highlight validators example
- import missing `get_session` helper for linter compliance
- drop unused import from auth schema

## Testing
- `ruff check . --fix`
- `pytest` *(fails: KeyError in demo auth tests; TypeError in specs generator)*

------
https://chatgpt.com/codex/tasks/task_e_689d074a8108832297b894e5f77bf826