### PR TITLE
Allow omitting route specs during registration

### DIFF
--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -372,13 +372,13 @@ def register_schemas(
                 spec.components.schema(schema_name, schema=schema)
 
 
-def register_routes_with_spec(architect: Architect, route_spec: list[dict[str, Any]] | None) -> None:
+def register_routes_with_spec(architect: Architect, route_spec: list[dict[str, Any]] | None = None) -> None:
     """Register routes and schemas with the API spec.
 
     Args:
         architect: The :class:`~flarchitect.Architect` instance.
-        route_spec: Routes and schemas to register with the apispec. ``None`` is
-            accepted to gracefully skip registration.
+        route_spec: Routes and schemas to register with the apispec. If ``None``,
+            registration is skipped. Defaults to ``None``.
 
     Returns:
         None


### PR DESCRIPTION
## Summary
- Make `route_spec` optional in `register_routes_with_spec`
- Clarify docstring and guard against empty or missing route specs

## Testing
- `ruff format flarchitect/specs/generator.py`
- `ruff check flarchitect/specs/generator.py --fix`
- `pytest tests/test_mutable_defaults.py::test_register_routes_with_spec_none -q`


------
https://chatgpt.com/codex/tasks/task_e_689d08934a64832288632d7908f2c686