### PR TITLE
docs: streamline feature overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ If you're new here, welcome! flarchitect gets you from data models to a fully fl
 
 ## Features
 
-- **Zero-configuration endpoints** – expose models as RESTful resources by adding a simple `Meta` class.
-- **Automatic documentation** – comprehensive Redoc or Swagger UI docs are generated at runtime and stay in sync with your models.
-- **SQLAlchemy integration** – works with plain SQLAlchemy or Flask-SQLAlchemy.
-- **Built-in authentication** – ship with JWT, basic and API key strategies out of the box, each exposing a simple `/auth/login` endpoint for credential validation, or plug in your own authentication.
-- **Rate limiting & structured responses** – configurable throttling and responses with a consistent schema.
-- **Highly configurable** – tweak behaviour globally via Flask config or per model with `Meta` attributes.
-- **Field validation** – built-in validators for emails, URLs, IPs and more.
-- **Nested writes** – opt-in support for sending related objects in POST/PUT payloads. Enable with `API_ALLOW_NESTED_WRITES = True` and let `AutoSchema` deserialize them automatically.
-- **CORS support** – enable cross-origin requests with `API_ENABLE_CORS`. See the [advanced configuration guide](docs/source/advanced_configuration.rst#cors) for an example.
+- **Automatic CRUD endpoints** – expose SQLAlchemy models as RESTful resources with a simple `Meta` class.
+- **Interactive documentation** – Redoc or Swagger UI generated at runtime and kept in sync with your models.
+- **Built-in authentication** – JWT, basic and API key strategies ship with a ready‑made `/auth/login` endpoint, or plug in your own.
+- **Extensibility hooks** – customise request and response flows.
 - **Soft delete** – hide and restore records without permanently removing them.
-- **Extensible callbacks** – hook into request/response flows to customise behaviour.
+
+### Optional extras
+
+- **Rate limiting & structured responses** – configurable throttling and consistent response schema.
+- **Field validation** – built-in validators for emails, URLs, IPs and more.
+- **Nested writes** – send related objects in POST/PUT payloads when `API_ALLOW_NESTED_WRITES` is `True`.
+- **CORS support** – enable cross-origin requests with `API_ENABLE_CORS`.
 
 ## Installation
 

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -30,9 +30,8 @@ from flarchitect.utils.general import (
     check_rate_services,
     validate_flask_limiter_rate_limit_string,
 )
-
 from flarchitect.utils.response_helpers import create_response
-
+from flarchitect.utils.session import get_session
 
 FLASK_APP_NAME = "flarchitect"
 

--- a/flarchitect/schemas/auth.py
+++ b/flarchitect/schemas/auth.py
@@ -1,5 +1,4 @@
 # Schema for loading login data (username and password)
-from typing import Any
 
 from marshmallow import Schema, ValidationError, fields, validates
 


### PR DESCRIPTION
## Summary
- Curate README feature list with core capabilities and optional extras
- Fix undefined name in architect by importing `get_session`
- Drop unused import from authentication schema

## Testing
- `ruff check . --fix`
- `pytest` *(fails: KeyError in authentication demo tests, TypeError in mutable defaults)*

------
https://chatgpt.com/codex/tasks/task_e_689d0748cf5c8322b841aa3ee6d40001