### PR TITLE
docs: document API_SESSION_GETTER

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -558,6 +558,18 @@
         - URI for the rate limiter's storage backend, e.g., ``redis://127.0.0.1:6379``.
           When omitted, ``flarchitect`` probes for Redis, Memcached, or MongoDB and falls back to in-memory storage.
           Use this to pin rate limiting to a specific service instead of auto-detection.
+    * - ``API_SESSION_GETTER``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``callable``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Callable returning a SQLAlchemy :class:`~sqlalchemy.orm.Session`.
+          Provides manual control over session retrieval when automatic
+          resolution is insufficient, such as with custom session factories
+          or multiple database binds. If unset, ``flarchitect`` attempts to
+          locate the session via Flask-SQLAlchemy, model ``query`` attributes,
+          or engine bindings.
     * - ``IGNORE_FIELDS``
 
           :bdg:`default:` ``None``

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -168,6 +168,29 @@ Please note the badge for each configuration value, as it defines where the valu
         See the :doc:`Model Method<config_locations/model_method>` page for more information.
 
 
+.. _custom-session-getter:
+
+Custom session getter
+---------------------
+
+``flarchitect`` tries to resolve the active SQLAlchemy session automatically
+from Flask-SQLAlchemy, model ``query`` attributes, or bound engines. When your
+application manages sessions differently—for example, using a custom factory or
+multiple database binds—you can supply :data:`API_SESSION_GETTER`.
+
+Provide a callable that returns a :class:`~sqlalchemy.orm.Session` instance:
+
+.. code:: python
+
+    from myapp.database import SessionLocal
+
+    class Config:
+        API_SESSION_GETTER = lambda: SessionLocal()
+
+This hook removes the need for model-level ``get_session`` methods and ensures
+``flarchitect`` uses the correct session in unconventional setups.
+
+
 Cascade delete settings
 -----------------------
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -39,7 +39,8 @@ SQLAlchemy, so no special ``get_session`` method is required.
 
 This setup gives **flarchitect** access to your models. The library automatically
 locates the active SQLAlchemy session. For non-Flask setups, a custom session
-resolver can be supplied via ``API_SESSION_GETTER`` in the Flask config.
+resolver can be supplied via ``API_SESSION_GETTER`` in the Flask config; see
+:ref:`custom-session-getter` for details.
 
 Configure Flask
 ----------------------------------------


### PR DESCRIPTION
## Summary
- document `API_SESSION_GETTER` in configuration table
- describe when to supply a custom session getter
- cross-reference session getter docs from quickstart

## Testing
- `pre-commit run --files docs/source/_configuration_table.rst docs/source/configuration.rst docs/source/quickstart.rst` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689d13b22d348322afa1b3eeb1dc2220