### PR TITLE
Add soft delete documentation and fix index toctree

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,11 @@ flarchitect
    extensions
    openapi
 
-=======
+.. toctree::
+   :maxdepth: 2
+   :caption: Configuration
+   :hidden:
+
    soft_delete
    configuration
    advanced_configuration

--- a/docs/source/soft_delete.rst
+++ b/docs/source/soft_delete.rst
@@ -1,0 +1,69 @@
+Soft delete
+===========
+
+flarchitect can mark records as deleted without removing them from the database.
+This allows you to hide data from normal queries while retaining it for
+auditing or future restoration.
+
+Configuration
+-------------
+
+Enable soft deletes and define how records are flagged:
+
+.. code-block:: python
+
+   class Config:
+       API_SOFT_DELETE = True
+       API_SOFT_DELETE_ATTRIBUTE = "deleted"
+       API_SOFT_DELETE_VALUES = (False, True)
+
+``API_SOFT_DELETE_ATTRIBUTE`` names the column that stores the deleted flag.
+``API_SOFT_DELETE_VALUES`` is a tuple where the first value represents an
+active record and the second marks it as deleted.
+
+Example model
+-------------
+
+Add a boolean column to your base model so every table can inherit the flag:
+
+.. code-block:: python
+
+   from datetime import datetime
+   from flask_sqlalchemy import SQLAlchemy
+   from sqlalchemy import Boolean, DateTime
+   from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+   class BaseModel(DeclarativeBase):
+       created: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+       updated: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+       deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+   db = SQLAlchemy(model_class=BaseModel)
+
+   class Book(db.Model):
+       __tablename__ = "books"
+       id: Mapped[int] = mapped_column(primary_key=True)
+       title: Mapped[str] = mapped_column()
+
+Example queries
+---------------
+
+Soft deleted rows are hidden from normal requests:
+
+.. code-block:: http
+
+   GET /api/books        # returns rows where deleted=False
+
+Include the ``include_deleted`` query parameter to return all rows:
+
+.. code-block:: http
+
+   GET /api/books?include_deleted=true
+
+Issuing a DELETE request marks the record as deleted. To remove it
+permanently, supply ``cascade_delete=1``:
+
+.. code-block:: http
+
+   DELETE /api/books/1             # sets deleted=True
+   DELETE /api/books/1?cascade_delete=1  # removes row from database


### PR DESCRIPTION
## Summary
- Fix broken `soft_delete` entry in index by introducing a Configuration toctree
- Add dedicated `soft_delete` page summarizing configuration and usage

## Testing
- `ruff check .`
- `pytest tests/test_soft_delete.py`
- `sphinx-build -b html docs/source docs/build/html` *(warnings: Inline literal start-string without end-string; Title underline too short; list-table parse errors; documents not in toctree)*

------
https://chatgpt.com/codex/tasks/task_e_689d13aaf3d0832295d675996eaf1d05