### PR TITLE
docs: document auto config flags

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -643,6 +643,35 @@
         - Companion flag to ``API_ALLOW_DELETE_RELATED`` covering association-table entries and similar dependents.
           Not currently evaluated by the code base; cascade behaviour hinges solely on ``API_ALLOW_CASCADE_DELETE``.
           Documented for completeness and potential future use.
+    * - ``AUTO_NAME_ENDPOINTS``
+
+          :bdg:`default:` ``True``
+          :bdg:`type` ``bool``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Automatically generates OpenAPI summaries from the schema and HTTP
+          method when no summary is supplied. Disable to preserve custom
+          summaries.
+
+          Example::
+
+              class Config:
+                  AUTO_NAME_ENDPOINTS = False
+
+    * - ``FULL_AUTO``
+
+          :bdg:`default:` ``True``
+          :bdg:`type` ``bool``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - When ``True`` ``flarchitect`` registers CRUD routes for all models at
+          startup. Set to ``False`` to define routes manually.
+
+        Example::
+
+              class Config:
+                  FULL_AUTO = False
+
     * - ``GET_MANY_SUMMARY``
 
           :bdg:`default:` ``None``

--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -10,6 +10,28 @@ metadata.
 As traffic increases, managing how often clients can hit your API becomes
 critical.
 
+Full auto mode
+--------------
+
+``flarchitect`` enables automatic route creation by default. With
+``FULL_AUTO = True`` the :class:`~flarchitect.Architect` scans your models at
+startup and registers CRUD routes for each one. This is convenient for new
+projects but may conflict with custom blueprints or hand-written views.
+
+Disable ``FULL_AUTO`` when you need to manage routes manually or only expose a
+subset of models. After turning it off you must call ``init_api`` explicitly to
+register any automatic routes you still require.
+
+.. code:: python
+
+    app = Flask(__name__)
+    app.config["FULL_AUTO"] = False
+    arch = Architect(app)
+    arch.init_api(app=app)  # manually trigger route generation
+
+Use this mode when integrating with existing applications or when automatic
+registration would create unwanted endpoints.
+
 Rate limiting
 -------------
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -168,6 +168,42 @@ Please note the badge for each configuration value, as it defines where the valu
         See the :doc:`Model Method<config_locations/model_method>` page for more information.
 
 
+Automatic generation
+--------------------
+
+Two flags control flarchitect's automatic behaviour when building routes and
+documentation.
+
+FULL_AUTO
+^^^^^^^^^
+
+When ``True`` (default), :class:`~flarchitect.Architect` inspects your SQLAlchemy
+models and registers CRUD routes for each one. Set ``FULL_AUTO`` to ``False`` if
+you plan to define routes manually or only want to initialise specific models.
+
+.. code:: python
+
+    class Config:
+        FULL_AUTO = False
+
+    app = Flask(__name__)
+    arch = Architect(app)
+    arch.init_api(app=app)  # call manually when FULL_AUTO is disabled
+
+AUTO_NAME_ENDPOINTS
+^^^^^^^^^^^^^^^^^^^
+
+``AUTO_NAME_ENDPOINTS`` defaults to ``True`` and automatically generates a
+summary line for each endpoint based on the schema and HTTP method. Disable it
+to keep custom summaries supplied via ``*_SUMMARY`` config options or
+callbacks.
+
+.. code:: python
+
+    class Config:
+        AUTO_NAME_ENDPOINTS = False
+
+
 Cascade delete settings
 -----------------------
 

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -5,6 +5,13 @@ Callbacks let you hook into the request lifecycle to run custom logic around
 database operations and responses. They can be declared globally in the Flask
 configuration or on individual SQLAlchemy models.
 
+.. note::
+
+   With ``AUTO_NAME_ENDPOINTS`` enabled (the default), flarchitect generates a
+   summary for each endpoint based on its schema and HTTP method. Disable this
+   flag if your callbacks provide custom summaries to prevent them from being
+   overwritten.
+
 Callback types
 --------------
 


### PR DESCRIPTION
## Summary
- describe FULL_AUTO and AUTO_NAME_ENDPOINTS configuration options with defaults and examples
- explain how FULL_AUTO interacts with manual routes
- note that AUTO_NAME_ENDPOINTS influences generated summaries

## Testing
- `ruff format .`
- `ruff check .`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689d13b7975883228589def077e571f7