### PR TITLE
docs: clarify caching fallback

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -145,14 +145,14 @@
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
-        - Flask-Caching backend used for caching GET responses. Examples include ``SimpleCache`` and ``RedisCache``. Requires the ``flask-caching`` package.
+        - Flask-Caching backend used for caching GET responses. Examples include ``SimpleCache`` and ``RedisCache``. Requires the ``flask-caching`` package. See :ref:`api_caching`.
     * - ``API_CACHE_TIMEOUT``
 
           :bdg:`default:` ``300``
           :bdg:`type` ``int``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
-        - Expiry time in seconds for cached responses. Only applicable when ``API_CACHE_TYPE`` is set.
+        - Expiry time in seconds for cached responses. Only applicable when ``API_CACHE_TYPE`` is set. See :ref:`api_caching`.
     * - ``API_ENABLE_CORS``
 
           :bdg:`default:` ``False``

--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -46,13 +46,29 @@ example, to shield a public search endpoint from abuse, you might allow only
 Because limits depend on counting requests, those counts must live
 somewhere.
 
-Caching backends
-----------------
+.. _api_caching:
 
-The rate limiter stores counters in a cache backend. When initialising,
+Caching backends
+-----------------
+
+``flarchitect`` can cache GET responses when ``API_CACHE_TYPE`` is set. If
+``flask-caching`` is installed, any of its backends (such as Redis or
+Memcached) may be used. When ``flask-caching`` is **not** available and
+``API_CACHE_TYPE`` is ``"SimpleCache"``, a bundled
+``SimpleCache`` provides an in-memory fallback. This lightweight cache is
+cleared when the process restarts and stores data only for the current
+worker, making it suitable for development or tests rather than
+production.
+
+Compared to ``flask-caching`` it lacks distributed backends, cache
+invalidation features and the broader decorator API. For deployments with
+multiple workers or where persistence matters, install ``flask-caching``
+and configure a production-ready backend instead.
+
+The rate limiter also stores counters in a cache backend. When initialising,
 ``flarchitect`` will automatically use a locally running Memcached,
-Redis or MongoDB instance. To point to a specific backend, supply a
-storage URI:
+Redis or MongoDB instance. To point to a specific backend, supply a storage
+URI:
 
 .. code:: python
 


### PR DESCRIPTION
## Summary
- document SimpleCache fallback for response caching and limitations compared to flask-caching
- link caching configuration options to new documentation section

## Testing
- `ruff format docs/source/advanced_configuration.rst docs/source/_configuration_table.rst` *(fails: Failed to parse docs/source/_configuration_table.rst:1:1: Expected a statement)*
- `sphinx-build -nW -b html docs/source docs/build/html` *(fails: The config value `ogp_custom_meta_tags' has type `list', defaults to `tuple'.)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d13a45168832299bbeeaae96059de