### PR TITLE
docs: clarify auth token schemas

### DIFF
--- a/flarchitect/schemas/auth.py
+++ b/flarchitect/schemas/auth.py
@@ -43,13 +43,15 @@ class LoginSchema(Schema):
             raise ValidationError("Password must be at least 6 characters long.")
 
 
-# Schema for dumping tokens (auth and refresh tokens)
 class TokenSchema(Schema):
+    """Serializes access and refresh tokens with the user primary key."""
+
     access_token = fields.String(required=True)
     refresh_token = fields.String(required=True)
     user_pk = fields.String(required=True)
 
 
-# Schema for dumping tokens (auth and refresh tokens)
 class RefreshSchema(Schema):
+    """Validates refresh-token payloads."""
+
     refresh_token = fields.String(required=True)


### PR DESCRIPTION
## Summary
- clarify purpose of token schemas with explicit docstrings

## Testing
- `ruff format flarchitect/schemas/auth.py`
- `ruff check flarchitect/schemas/auth.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d1391ba8c8322a8d333d8cf45c837