### PR TITLE
Add package docstrings and exports

### DIFF
--- a/flarchitect/core/__init__.py
+++ b/flarchitect/core/__init__.py
@@ -1,0 +1,18 @@
+"""Core routing utilities and caching primitives.
+
+This package exposes the main classes used to build and register API
+endpoints as well as a lightweight in-memory cache for environments where
+``flask_caching`` is unavailable.
+"""
+
+from .architect import Architect, jwt_authentication
+from .routes import RouteCreator, find_rule_by_function
+from .simple_cache import SimpleCache
+
+__all__ = [
+    "Architect",
+    "jwt_authentication",
+    "RouteCreator",
+    "find_rule_by_function",
+    "SimpleCache",
+]

--- a/flarchitect/database/__init__.py
+++ b/flarchitect/database/__init__.py
@@ -1,0 +1,17 @@
+"""Database helpers providing CRUD services and SQLAlchemy utilities."""
+
+from .operations import (
+    CrudService,
+    apply_sorting_to_query,
+    get_model_columns,
+    get_model_relationships,
+    paginate_query,
+)
+
+__all__ = [
+    "CrudService",
+    "apply_sorting_to_query",
+    "get_model_columns",
+    "get_model_relationships",
+    "paginate_query",
+]

--- a/flarchitect/schemas/__init__.py
+++ b/flarchitect/schemas/__init__.py
@@ -1,0 +1,15 @@
+"""Marshmallow schemas and utilities for serialization and validation."""
+
+from .auth import LoginSchema, RefreshSchema, TokenSchema
+from .bases import AutoSchema, Base, DeleteSchema
+from .utils import get_input_output_from_model_or_make
+
+__all__ = [
+    "AutoSchema",
+    "Base",
+    "DeleteSchema",
+    "LoginSchema",
+    "RefreshSchema",
+    "TokenSchema",
+    "get_input_output_from_model_or_make",
+]

--- a/flarchitect/specs/__init__.py
+++ b/flarchitect/specs/__init__.py
@@ -1,0 +1,13 @@
+"""OpenAPI specification generation and helper utilities."""
+
+from importlib import import_module
+from typing import Any
+
+__all__ = ["CustomSpec", "register_routes_with_spec", "register_schemas"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple proxy
+    if name in __all__:
+        module = import_module("flarchitect.specs.generator")
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -1,0 +1,28 @@
+import flarchitect.core as core
+import flarchitect.database as database
+import flarchitect.schemas as schemas
+import flarchitect.specs as specs
+
+
+def test_core_exports_and_docstring():
+    assert core.__doc__
+    assert core.Architect.__name__ == "Architect"
+    assert "Architect" in core.__all__
+
+
+def test_database_exports_and_docstring():
+    assert database.__doc__
+    assert database.CrudService.__name__ == "CrudService"
+    assert "CrudService" in database.__all__
+
+
+def test_schemas_exports_and_docstring():
+    assert schemas.__doc__
+    assert isinstance(schemas.AutoSchema, type)
+    assert "AutoSchema" in schemas.__all__
+
+
+def test_specs_exports_and_docstring():
+    assert specs.__doc__
+    assert specs.CustomSpec.__name__ == "CustomSpec"
+    assert "CustomSpec" in specs.__all__


### PR DESCRIPTION
## Summary
- document core, database, schemas and specs packages with module docstrings
- export primary public classes and helpers via `__all__`
- add tests covering package exports

## Testing
- `ruff check --fix flarchitect/core/__init__.py flarchitect/database/__init__.py flarchitect/schemas/__init__.py flarchitect/specs/__init__.py tests/test_package_exports.py`
- `pytest tests/test_package_exports.py`


------
https://chatgpt.com/codex/tasks/task_e_689d138e4d108322b0814d40c9f3109e