### PR TITLE
docs: explain cache and cors fallbacks

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -145,7 +145,11 @@
           :bdg:`type` ``str``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
-        - Flask-Caching backend used for caching GET responses. Examples include ``SimpleCache`` and ``RedisCache``. Requires the ``flask-caching`` package.
+        - Flask-Caching backend used for caching ``GET`` responses. Specify
+          names like ``RedisCache`` when the ``flask-caching`` package is
+          installed. Without that dependency, only ``SimpleCache`` is supported
+          through a small built-in fallback; other values raise a runtime
+          error.
     * - ``API_CACHE_TIMEOUT``
 
           :bdg:`default:` ``300``
@@ -159,7 +163,10 @@
           :bdg:`type` ``bool``
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
-        - Enables Cross-Origin Resource Sharing using ``flask-cors`` so browser clients from other origins can access the API.
+        - Enables Cross-Origin Resource Sharing. If ``flask-cors`` is present
+          the settings are delegated to it; otherwise a minimal
+          ``Access-Control-Allow-Origin`` header is applied based on
+          ``CORS_RESOURCES``.
     * - ``API_XML_AS_TEXT``
 
           :bdg:`default:` ``False``

--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -64,10 +64,17 @@ with rate-limit headers enabled by default. In production, you might point
 to a shared Redis cluster so that multiple application servers enforce the
 same limits.
 
+You can also cache ``GET`` responses by choosing a backend with
+``API_CACHE_TYPE``. When `flask-caching <https://flask-caching.readthedocs.io/>`_
+is installed, set ``API_CACHE_TYPE`` to any supported backend such as
+``RedisCache``. If the extension is missing, specifying ``SimpleCache``
+activates a small in-memory cache bundled with ``flarchitect``; any other
+value will raise a :class:`RuntimeError`. Use ``API_CACHE_TIMEOUT`` to control
+how long items remain cached.
+For a runnable example demonstrating cached responses see the `caching demo <https://github.com/lewis-morris/flarchitect/tree/master/demo/caching>`_.
+
 After securing throughput, you can also shape what your clients see in each
 payload.
-
-For a runnable example demonstrating cached responses see the `caching demo <https://github.com/lewis-morris/flarchitect/tree/master/demo/caching>`_.
 
 Response metadata
 -----------------
@@ -260,6 +267,18 @@ options, mirroring the format used by `Flask-CORS <https://flask-cors.readthedoc
         CORS_RESOURCES = {
             r"/api/*": {"origins": "*"}
         }
+
+If ``flask-cors`` is installed, these settings are passed through to that
+extension. Without it, ``flarchitect`` compiles the patterns in
+``CORS_RESOURCES`` and adds an ``Access-Control-Allow-Origin`` header for
+matching requests. Only origin checking is performed; other CORS headers are
+left untouched.
+
+``flask-cors``\ -free minimal configuration::
+
+    class Config:
+        API_ENABLE_CORS = True
+        CORS_RESOURCES = {r"/api/*": {"origins": ["https://example.com"]}}
 
 Example
 ^^^^^^^


### PR DESCRIPTION
## Summary
- document SimpleCache fallback and choosing a cache backend
- clarify CORS behaviour without Flask-CORS and show minimal config
- update configuration table for API_CACHE_TYPE and API_ENABLE_CORS

## Testing
- `ruff check flarchitect`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d13c02904832299aca9eb283be9bc