### PR TITLE
Add example scaffolding for JWT-enabled Flask API

### DIFF
--- a/Scaffolding/__init__.py
+++ b/Scaffolding/__init__.py
@@ -1,0 +1,5 @@
+"""Scaffolding package exposing load function."""
+
+from .load import load
+
+__all__ = ["load"]

--- a/Scaffolding/config.py
+++ b/Scaffolding/config.py
@@ -1,0 +1,31 @@
+"""Configuration module for the scaffolding application."""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+
+class Config:
+    """Base configuration with sensible defaults.
+
+    Environment variables may override these values. Each option lists
+    possible values and defaults for clarity.
+    """
+
+    SECRET_KEY = os.getenv("SECRET_KEY", "dev")  # str: secret for session and JWT; default "dev"
+    SQLALCHEMY_DATABASE_URI = os.getenv("DATABASE_URL", "sqlite:///:memory:")  # str: any SQLAlchemy-supported URI; default in-memory SQLite
+    SQLALCHEMY_TRACK_MODIFICATIONS = False  # bool: enable change tracking; default False
+    JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev-jwt-secret")  # str: secret used to sign JWTs; default "dev-jwt-secret"
+    JWT_ACCESS_TOKEN_EXPIRES = timedelta(minutes=15)  # timedelta: token lifetime; default 15 minutes
+    JWT_TOKEN_LOCATION = ["headers"]  # list[str]: where to read JWTs ("headers", "cookies", "json"); default ["headers"]
+    DEBUG = os.getenv("DEBUG", False)  # bool: enable debug mode; default False
+    USERNAME_MIN_LENGTH = 3  # int: minimum username length; default 3
+
+
+class TestingConfig(Config):
+    """Configuration used during unit tests."""
+
+    TESTING = True  # bool: put Flask in testing mode
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"  # use in-memory DB for tests
+    JWT_ACCESS_TOKEN_EXPIRES = timedelta(minutes=1)  # shorter token lifetime for tests

--- a/Scaffolding/load.py
+++ b/Scaffolding/load.py
@@ -1,0 +1,18 @@
+"""Application loader for the scaffolding example."""
+
+from flask import Flask
+
+from .module import create_app
+
+
+def load(config_class: str = "Scaffolding.config.Config") -> Flask:
+    """Create and return a configured Flask application.
+
+    Args:
+        config_class: Dotted path to the configuration object.
+
+    Returns:
+        Configured :class:`flask.Flask` application.
+    """
+
+    return create_app(config_class)

--- a/Scaffolding/module/__init__.py
+++ b/Scaffolding/module/__init__.py
@@ -1,0 +1,30 @@
+"""Application factory for the scaffolding example."""
+
+from flask import Flask
+
+from .extensions import db, jwt
+from .routes import api_bp
+
+
+def create_app(config_class: str) -> Flask:
+    """Application factory.
+
+    Args:
+        config_class: Dotted path to the configuration object.
+
+    Returns:
+        Configured :class:`flask.Flask` application.
+    """
+
+    app = Flask(__name__)
+    app.config.from_object(config_class)
+
+    db.init_app(app)
+    jwt.init_app(app)
+
+    app.register_blueprint(api_bp)
+
+    with app.app_context():
+        db.create_all()
+
+    return app

--- a/Scaffolding/module/extensions.py
+++ b/Scaffolding/module/extensions.py
@@ -1,0 +1,10 @@
+"""Extension instances for the scaffolding application."""
+
+from flask_jwt_extended import JWTManager
+from flask_sqlalchemy import SQLAlchemy
+
+# Instantiate extensions globally to be initialized in the app factory.
+db = SQLAlchemy()
+jwt = JWTManager()
+
+__all__ = ["db", "jwt"]

--- a/Scaffolding/module/models.py
+++ b/Scaffolding/module/models.py
@@ -1,0 +1,55 @@
+"""Database models for the scaffolding application."""
+
+from __future__ import annotations
+
+from flask import current_app
+from sqlalchemy.orm import validates
+from validators import email as validate_email
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from .extensions import db
+
+
+class User(db.Model):
+    """User account model."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+    @validates("email")
+    def validate_email(self, key: str, address: str) -> str:
+        """Ensure e-mail addresses are valid."""
+
+        if not validate_email(address):
+            raise ValueError("Invalid email address")
+        return address
+
+    @validates("username")
+    def validate_username(self, key: str, username: str) -> str:
+        """Validate username length from configuration."""
+
+        min_len = int(current_app.config.get("USERNAME_MIN_LENGTH", 3))
+        if len(username) < min_len:
+            raise ValueError(f"Username must be at least {min_len} characters long")
+        return username
+
+    def set_password(self, password: str) -> None:
+        """Hash and store the user's password."""
+
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password: str) -> bool:
+        """Check a password against the stored hash."""
+
+        return check_password_hash(self.password_hash, password)
+
+
+class Item(db.Model):
+    """Example model representing a user-owned item."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    owner_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+    owner = db.relationship("User", backref="items")

--- a/Scaffolding/module/routes.py
+++ b/Scaffolding/module/routes.py
@@ -1,0 +1,55 @@
+"""API routes for the scaffolding example."""
+
+from __future__ import annotations
+
+from flask import Blueprint, request
+from flask_jwt_extended import create_access_token, get_jwt_identity, jwt_required
+
+from .extensions import db
+from .models import User
+
+api_bp = Blueprint("api", __name__)
+
+
+@api_bp.post("/register")
+def register() -> tuple[dict[str, str], int]:
+    """Register a new user."""
+
+    data = request.get_json() or {}
+    username = data.get("username")
+    email = data.get("email")
+    password = data.get("password")
+
+    if not all([username, email, password]):
+        return {"message": "Missing fields"}, 400
+
+    user = User(username=username, email=email)
+    user.set_password(password)
+    db.session.add(user)
+    db.session.commit()
+    return {"message": "User created"}, 201
+
+
+@api_bp.post("/login")
+def login() -> tuple[dict[str, str], int]:
+    """Authenticate a user and return a JWT."""
+
+    data = request.get_json() or {}
+    username = data.get("username")
+    password = data.get("password")
+
+    user = User.query.filter_by(username=username).first()
+    if user and user.check_password(password):
+        token = create_access_token(identity=str(user.id))
+        return {"access_token": token}, 200
+
+    return {"message": "Invalid credentials"}, 401
+
+
+@api_bp.get("/protected")
+@jwt_required()
+def protected() -> tuple[dict[str, int], int]:
+    """Return the current user's identity."""
+
+    user_id = int(get_jwt_identity())
+    return {"user_id": user_id}, 200

--- a/tests/test_scaffolding.py
+++ b/tests/test_scaffolding.py
@@ -1,0 +1,44 @@
+"""Tests for the scaffolding example."""
+
+from __future__ import annotations
+
+import pytest
+
+from Scaffolding import load
+from Scaffolding.module.extensions import db
+from Scaffolding.module.models import User
+
+
+@pytest.fixture()
+def app():
+    app = load("Scaffolding.config.TestingConfig")
+    yield app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def test_register_login_and_protected(client):
+    response = client.post(
+        "/register",
+        json={"username": "tester", "email": "tester@example.com", "password": "secret"},
+    )
+    assert response.status_code == 201
+
+    response = client.post("/login", json={"username": "tester", "password": "secret"})
+    assert response.status_code == 200
+    token = response.get_json()["access_token"]
+
+    response = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    assert response.get_json()["user_id"] == 1
+
+
+def test_username_validation(app):
+    with app.app_context(), pytest.raises(ValueError):
+        user = User(username="ab", email="a@example.com")
+        user.set_password("secret")
+        db.session.add(user)
+        db.session.commit()


### PR DESCRIPTION
## Summary
- add Scaffolding package demonstrating a Flask application factory with JWT auth and models
- provide configuration module with documented options
- include unit tests verifying registration, login, and protected routes

## Testing
- `ruff format Scaffolding tests/test_scaffolding.py`
- `ruff check --fix Scaffolding tests/test_scaffolding.py`
- `pytest tests/test_scaffolding.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8a2830548322aad682b69df948fe