### PR TITLE
docs: clarify API docs configuration

### DIFF
--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -1,12 +1,25 @@
-OpenAPI Specification
+API Documentation
 =========================================
 
 flarchitect automatically generates an OpenAPI 3.0.2 document for every
-registered model. The specification powers the interactive Redoc page and
-can also be rendered with Swagger UI by setting ``API_DOCS_STYLE = 'swagger'``
-in your Flask configuration. You can inject additional `<head>` tags into
-the documentation with ``API_DOCUMENTATION_HEADERS``. The raw spec can also be
-reused with external tools like Postman.
+registered model. The specification powers an interactive documentation page
+which can be served with either Redoc or Swagger UI. The raw specification is
+standard OpenAPI and can be consumed by external tools such as Postman.
+
+Documentation style
+-------------------
+
+By default, flarchitect renders docs with Redoc. To switch to Swagger UI set
+``API_DOCS_STYLE = "swagger"`` in your Flask configuration. The only accepted
+values are ``"redoc"`` and ``"swagger"``. Redoc provides a clean read-only
+reference, while Swagger UI adds an interactive "try it out" console:
+
+.. code-block:: python
+
+    app.config["API_DOCS_STYLE"] = "swagger"
+
+The documentation itself is hosted at ``API_DOCUMENTATION_URL`` (default
+``/docs``).
 
 Automatic generation
 --------------------
@@ -39,13 +52,15 @@ Customising the document
 
 A number of configuration keys let you tailor the output:
 
-* ``API_DOCS_STYLE`` – choose between Redoc and Swagger UI
-* ``API_DOCUMENTATION_HEADERS`` – inject extra HTML into the docs page
-* ``API_TITLE`` – title displayed in the document
-* ``API_VERSION`` – semantic version string
-* ``API_DESCRIPTION`` – path to a README-style file rendered into the
-  ``info`` section
-* ``API_LOGO_URL`` and ``API_LOGO_BACKGROUND`` – brand the Redoc page
+* ``API_DOCUMENTATION_HEADERS`` – HTML string inserted into the ``<head>`` of
+  the docs page. Use for meta tags or custom scripts.
+* ``API_TITLE`` – plain text displayed as the documentation title.
+* ``API_VERSION`` – semantic version string such as ``"1.0.0"``.
+* ``API_DESCRIPTION`` – free text or a filepath to a README-style file rendered
+  into the ``info`` section.
+* ``API_LOGO_URL`` – URL or static path to an image used as the logo.
+* ``API_LOGO_BACKGROUND`` – CSS colour value behind the logo (e.g.
+  ``"#fff"`` or ``"transparent"``).
 
 See :doc:`configuration` for the full list of options.
 


### PR DESCRIPTION
## Summary
- rename OpenAPI page to "API Documentation"
- document Redoc vs Swagger UI backends
- describe expected values for documentation config keys

## Testing
- `ruff check . --no-fix`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d8b48edac8322abb6a25f11e47372