### PR TITLE
docs: reorganize configuration guide

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -1,3 +1,57 @@
+Core Settings
+-------------
+
+Essential configuration values needed to run ``flarchitect`` and control automatic route generation.
+
+.. list-table::
+
+    * - ``API_TITLE``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``str``
+          :bdg-danger:`Required` :bdg-dark-line:`Global`
+
+        - Sets the display title of the generated documentation. Provide a concise project name or API identifier. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``API_VERSION``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``str``
+          :bdg-danger:`Required` :bdg-dark-line:`Global`
+
+        - Defines the version string shown in the docs header, helping consumers track API revisions. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``FULL_AUTO``
+
+          :bdg:`default:` ``True``
+          :bdg:`type` ``bool``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - When ``True`` ``flarchitect`` registers CRUD routes for all models at
+          startup. Set to ``False`` to define routes manually.
+
+        Example::
+
+              class Config:
+                  FULL_AUTO = False
+
+    * - ``AUTO_NAME_ENDPOINTS``
+
+          :bdg:`default:` ``True``
+          :bdg:`type` ``bool``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Automatically generates OpenAPI summaries from the schema and HTTP
+          method when no summary is supplied. Disable to preserve custom
+          summaries.
+
+          Example::
+
+              class Config:
+                  AUTO_NAME_ENDPOINTS = False
+
+
+Optional Settings
+-----------------
+
 .. list-table::
 
     * - ``API_CREATE_DOCS``
@@ -36,20 +90,6 @@
 
         - Path where the raw OpenAPI document is served. Override to change the
           URL exposed by the automatic endpoint.
-    * - ``API_TITLE``
-
-          :bdg:`default:` ``None``
-          :bdg:`type` ``str``
-          :bdg-danger:`Required` :bdg-dark-line:`Global`
-
-        - Sets the display title of the generated documentation. Provide a concise project name or API identifier. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
-    * - ``API_VERSION``
-
-          :bdg:`default:` ``None``
-          :bdg:`type` ``str``
-          :bdg-danger:`Required` :bdg-dark-line:`Global`
-
-        - Defines the version string shown in the docs header, helping consumers track API revisions. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
     * - ``API_LOGO_URL``
 
           :bdg:`default:` ``None``
@@ -677,35 +717,6 @@
         - Companion flag to ``API_ALLOW_DELETE_RELATED`` covering association-table entries and similar dependents.
           Not currently evaluated by the code base; cascade behaviour hinges solely on ``API_ALLOW_CASCADE_DELETE``.
           Documented for completeness and potential future use.
-    * - ``AUTO_NAME_ENDPOINTS``
-
-          :bdg:`default:` ``True``
-          :bdg:`type` ``bool``
-          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
-
-        - Automatically generates OpenAPI summaries from the schema and HTTP
-          method when no summary is supplied. Disable to preserve custom
-          summaries.
-
-          Example::
-
-              class Config:
-                  AUTO_NAME_ENDPOINTS = False
-
-    * - ``FULL_AUTO``
-
-          :bdg:`default:` ``True``
-          :bdg:`type` ``bool``
-          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
-
-        - When ``True`` ``flarchitect`` registers CRUD routes for all models at
-          startup. Set to ``False`` to define routes manually.
-
-        Example::
-
-              class Config:
-                  FULL_AUTO = False
-
     * - ``GET_MANY_SUMMARY``
 
           :bdg:`default:` ``None``

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -167,42 +167,30 @@ Please note the badge for each configuration value, as it defines where the valu
 
         See the :doc:`Model Method<config_locations/model_method>` page for more information.
 
-
-Automatic generation
+Core configuration
 --------------------
 
-Two flags control flarchitect's automatic behaviour when building routes and
-documentation.
+Some settings are essential for initialising the extension and controlling its
+automatic behaviour.
 
-FULL_AUTO
-^^^^^^^^^
-
-When ``True`` (default), :class:`~flarchitect.Architect` inspects your SQLAlchemy
-models and registers CRUD routes for each one. Set ``FULL_AUTO`` to ``False`` if
-you plan to define routes manually or only want to initialise specific models.
+At a minimum, provide a title and version for your API:
 
 .. code:: python
 
     class Config:
-        FULL_AUTO = False
+        API_TITLE = "My API"
+        API_VERSION = "1.0"
 
-    app = Flask(__name__)
-    arch = Architect(app)
-    arch.init_api(app=app)  # call manually when FULL_AUTO is disabled
-
-AUTO_NAME_ENDPOINTS
-^^^^^^^^^^^^^^^^^^^
-
-``AUTO_NAME_ENDPOINTS`` defaults to ``True`` and automatically generates a
-summary line for each endpoint based on the schema and HTTP method. Disable it
-to keep custom summaries supplied via ``*_SUMMARY`` config options or
-callbacks.
+Two additional flags, ``FULL_AUTO`` and ``AUTO_NAME_ENDPOINTS``, toggle the
+automatic registration of routes and the generation of default endpoint
+summaries. Both default to ``True`` and may be disabled when you need manual
+control.
 
 .. code:: python
 
     class Config:
-        AUTO_NAME_ENDPOINTS = False
-
+        FULL_AUTO = False           # register routes manually
+        AUTO_NAME_ENDPOINTS = False # keep custom summaries
 
 
 Cascade delete settings


### PR DESCRIPTION
## Summary
- clarify required configuration and automatic flags
- split configuration reference into core and optional sections

## Testing
- `ruff check .`
- `ruff format docs/source/configuration.rst docs/source/_configuration_table.rst` (fails: Failed to parse .rst files)
- `pytest` (fails: 36 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_689d8d4e065c8322a28f501fc153a812