### PR TITLE
Fix test imports and scaffolding load path

### DIFF
--- a/demo/scaffolding/__init__.py
+++ b/demo/scaffolding/__init__.py
@@ -1,5 +1,6 @@
-"""Scaffolding package exposing load function."""
+"""Scaffolding package exposing the load helper and models."""
 
 from .load import load
+from .module.models import User
 
-__all__ = ["load"]
+__all__ = ["load", "User"]

--- a/demo/scaffolding/load.py
+++ b/demo/scaffolding/load.py
@@ -1,5 +1,7 @@
 """Application loader for the scaffolding example."""
 
+from __future__ import annotations
+
 from flask import Flask
 
 from .module import create_app
@@ -9,11 +11,16 @@ def load(config_class: str = "Scaffolding.config.Config") -> Flask:
     """Create and return a configured Flask application.
 
     Args:
-        config_class: Dotted path to the configuration object.
+        config_class: Dotted path to the configuration object. For backwards
+            compatibility, paths beginning with ``Scaffolding`` are remapped to
+            this package.
 
     Returns:
         Configured :class:`flask.Flask` application.
     """
+
+    if config_class.startswith("Scaffolding."):
+        config_class = config_class.replace("Scaffolding", "demo.scaffolding", 1)
 
     return create_app(config_class)
 

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,12 +1,17 @@
 """Tests for logging utilities."""
 
 import importlib.util
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 
 from colorama import Fore
 
 # Import the logging module directly to avoid package-level imports requiring external deps.
-spec = importlib.util.spec_from_file_location("flarchitect_logging", Path("flarchitect/logging.py"))
+project_root = Path(__file__).resolve().parents[1]
+spec: ModuleSpec | None = importlib.util.spec_from_file_location(
+    "flarchitect_logging",
+    project_root / "flarchitect" / "logging.py",
+)
 flarchitect_logging = importlib.util.module_from_spec(spec)
 assert spec and spec.loader
 spec.loader.exec_module(flarchitect_logging)
@@ -14,7 +19,7 @@ CustomLogger = flarchitect_logging.CustomLogger
 color_text_with_multiple_patterns = flarchitect_logging.color_text_with_multiple_patterns
 
 
-def test_color_text_with_multiple_patterns_replaces_wrappers():
+def test_color_text_with_multiple_patterns_replaces_wrappers() -> None:
     text = "This is `code`, +danger+, --info--, $price$, and |success|."
     colored = color_text_with_multiple_patterns(text)
     assert Fore.YELLOW in colored
@@ -29,7 +34,7 @@ def test_color_text_with_multiple_patterns_replaces_wrappers():
     assert "|success|" not in colored
 
 
-def test_custom_logger_respects_verbosity(capsys):
+def test_custom_logger_respects_verbosity(capsys) -> None:
     logger = CustomLogger(verbosity_level=1)
     logger.log(1, "hi")
     out = capsys.readouterr().out
@@ -40,7 +45,7 @@ def test_custom_logger_respects_verbosity(capsys):
     assert out == ""
 
 
-def test_custom_logger_error_color(capsys):
+def test_custom_logger_error_color(capsys) -> None:
     logger = CustomLogger(verbosity_level=1)
     logger.error(1, "boom")
     out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Ensure logging tests load modules relative to project root
- Export `User` model from demo scaffolding package
- Allow `demo.scaffolding.load` to resolve legacy `Scaffolding.*` config paths

## Testing
- `ruff check demo/scaffolding/__init__.py demo/scaffolding/load.py tests/test_logging_utils.py`
- `ruff format demo/scaffolding/__init__.py demo/scaffolding/load.py tests/test_logging_utils.py`
- `pytest tests/test_logging_utils.py tests/test_scaffolding.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_limiter', 'marshmallow', 'numpy', 'apispec', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689d90200af883228d46c15442701cbf