### PR TITLE
Fix circular import in scaffolding demo

### DIFF
--- a/demo/scaffolding/load.py
+++ b/demo/scaffolding/load.py
@@ -2,9 +2,27 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
-from module import create_app
+try:  # pragma: no cover - prefer package import
+    from .module import create_app
+except ImportError:  # pragma: no cover - direct script execution
+    import sys
+    from pathlib import Path
+
+    sys.path.append(str(Path(__file__).resolve().parent))
+    from module import create_app  # type: ignore
+
+if TYPE_CHECKING:  # pragma: no cover
+    from flask import Flask
+
+
+def load() -> Flask:
+    """Return a configured :class:`~flask.Flask` app for the demo."""
+
+    return create_app()
+
 
 if __name__ == "__main__":
-    app = create_app()
-    app.run(host="0.0.0.0", port=5000, debug=True)
+    flask_app = load()
+    flask_app.run(host="0.0.0.0", port=5000, debug=True)

--- a/demo/scaffolding/module/config.py
+++ b/demo/scaffolding/module/config.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import os
 
-from demo.scaffolding.module.extensions import db
-from demo.scaffolding.module.models import User
+from .extensions import db
+from .models import User
 
 
 class Config:

--- a/tests/test_demo_scaffolding_imports.py
+++ b/tests/test_demo_scaffolding_imports.py
@@ -1,0 +1,8 @@
+"""Unit tests for scaffolding config imports."""
+
+from demo.scaffolding.module.config import Config
+
+
+def test_config_import() -> None:
+    """Config can be imported without triggering circular imports."""
+    assert Config.API_TITLE == "Scaffolding API"


### PR DESCRIPTION
## Summary
- resolve circular import in scaffolding demo by using relative imports
- add loader helper and fallback import logic for running the demo
- add regression test for importing scaffolding config

## Testing
- `ruff check --fix demo/scaffolding/load.py demo/scaffolding/module/config.py tests/test_demo_scaffolding_imports.py`
- `ruff format demo/scaffolding/load.py demo/scaffolding/module/config.py tests/test_demo_scaffolding_imports.py`
- `pytest tests/test_demo_scaffolding_imports.py tests/test_demo_scaffolding.py::test_scaffolding_jwt_auth -q`


------
https://chatgpt.com/codex/tasks/task_e_689d98530f988322831afe1ff6c82aab