### PR TITLE
feat: add optional docs password

### DIFF
--- a/demo/scaffolding/module/__init__.py
+++ b/demo/scaffolding/module/__init__.py
@@ -2,8 +2,8 @@
 
 from flask import Flask
 
-from .extensions import db, schema
 from .config import Config
+from .extensions import db, schema
 
 
 def create_app() -> Flask:

--- a/demo/scaffolding/module/config.py
+++ b/demo/scaffolding/module/config.py
@@ -29,6 +29,7 @@ class Config:
     API_ALLOW_NESTED_WRITES = False
     API_CREATE_DOCS = True
     API_ENABLE_CORS = False
+    API_DOCUMENTATION_PASSWORD = os.getenv("API_DOCUMENTATION_PASSWORD")
 
     # Authentication configuration
     API_AUTHENTICATE = True

--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -78,6 +78,13 @@ Documentation Settings
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - URL path where documentation is served. Useful for mounting docs under a custom route such as ``/redoc``. Accepts any valid path string. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``API_DOCUMENTATION_PASSWORD``
+
+          :bdg:`default:` ``None``
+          :bdg:`type` ``str``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Enables optional basic auth protection for docs and ``swagger.json``. Set the ``API_DOCUMENTATION_PASSWORD`` environment variable to require this password.
     * - ``API_DOCS_STYLE``
 
           :bdg:`default:` ``redoc``

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -27,4 +27,5 @@ Because the demo starts with no records, that list is empty:
        "value": []
    }
 
-Pop open ``http://localhost:5000/docs`` in your browser to explore the automatically generated API docs.
+ Pop open ``http://localhost:5000/docs`` in your browser to explore the automatically generated API docs.
+ To optionally restrict access, set the ``API_DOCUMENTATION_PASSWORD`` environment variable and supply that password via HTTP Basic auth when visiting the docs.

--- a/tests/test_docs_password.py
+++ b/tests/test_docs_password.py
@@ -1,0 +1,23 @@
+import base64
+
+from demo.basic_factory.basic_factory import create_app as factory_app
+from demo.scaffolding.module import create_app as scaffold_app
+
+
+def test_docs_accessible_without_password():
+    app = scaffold_app()
+    client = app.test_client()
+    resp = client.get("/docs")
+    assert resp.status_code == 200
+
+
+def test_docs_password_protected():
+    app = factory_app({"API_DOCUMENTATION_PASSWORD": "letmein"})
+    client = app.test_client()
+
+    resp = client.get("/docs")
+    assert resp.status_code == 401
+
+    token = base64.b64encode(b"user:letmein").decode()
+    resp = client.get("/docs", headers={"Authorization": f"Basic {token}"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- make docs and swagger routes bypass global auth and optionally require API_DOCUMENTATION_PASSWORD
- document how to protect docs and expose env var in scaffolding config
- add regression tests for docs password behaviour

## Testing
- `ruff check . --fix`
- `pytest tests/test_docs_password.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d9d1752948322996bf0d494599b7e