### PR TITLE
Improve session utility test coverage

### DIFF
--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -155,6 +155,12 @@ class TestConvertCase:
 
         assert convert_case("hello", "unknown") == "hello"
 
+    def test_handles_non_alphanumeric_string(self) -> None:
+        """Strings lacking letters or numbers remain unchanged."""
+
+        s = "___"
+        assert convert_case(s, "camel") == s
+
 
 class TestPluralizeLastWord:
     #  pluralizes last word in camelCase

--- a/tests/test_session_helper.py
+++ b/tests/test_session_helper.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy import Integer, create_engine
@@ -44,3 +47,72 @@ def test_get_session_plain_sqlalchemy() -> None:
         assert isinstance(session, Session)
     finally:
         session.close()
+
+
+def test_get_session_custom_getter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Session resolves via configured callable."""
+
+    engine = create_engine("sqlite:///:memory:")
+    custom_session = Session(bind=engine)
+
+    def custom_getter() -> Session:
+        return custom_session
+
+    monkeypatch.setattr("flarchitect.utils.session.get_config_or_model_meta", lambda *_, **__: custom_getter)
+    try:
+        assert get_session() is custom_session
+    finally:
+        custom_session.close()
+
+
+def test_get_session_from_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Session resolves from ``model.query.session`` attribute."""
+
+    session_obj = object()
+
+    class Model:
+        query = SimpleNamespace(session=session_obj)
+
+    monkeypatch.setattr("flarchitect.utils.session.get_config_or_model_meta", lambda *_, **__: None)
+    assert get_session(Model) is session_obj
+
+
+def test_get_session_legacy_method(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Session resolves from model's legacy ``get_session`` method."""
+
+    session_obj = object()
+
+    class Model:
+        @staticmethod
+        def get_session() -> object:
+            return session_obj
+
+    monkeypatch.setattr("flarchitect.utils.session.get_config_or_model_meta", lambda *_, **__: None)
+    assert get_session(Model) is session_obj
+
+
+def test_get_session_model_metadata_bind(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Session derives from ``model.metadata.bind`` when ``__table__`` is absent."""
+
+    engine = create_engine("sqlite:///:memory:")
+
+    class Model:
+        metadata = SimpleNamespace(bind=engine)
+
+    monkeypatch.setattr("flarchitect.utils.session.get_config_or_model_meta", lambda *_, **__: None)
+    session = get_session(Model)
+    try:
+        assert isinstance(session, Session)
+    finally:
+        session.close()
+
+
+def test_get_session_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An error is raised when no session strategy matches."""
+
+    class Model:
+        pass
+
+    monkeypatch.setattr("flarchitect.utils.session.get_config_or_model_meta", lambda *_, **__: None)
+    with pytest.raises(RuntimeError):
+        get_session(Model)


### PR DESCRIPTION
## Summary
- Add coverage for edge case in `convert_case` where input lacks alphanumeric characters
- Expand session resolution tests for custom getter, query attribute, legacy method, metadata bind fallback, and error handling

## Testing
- `ruff format tests/test_functions.py tests/test_session_helper.py && ruff check tests/test_functions.py tests/test_session_helper.py --fix`
- `pytest tests/test_functions.py tests/test_session_helper.py --cov=flarchitect`


------
https://chatgpt.com/codex/tasks/task_e_689d9c168a3483229755e909c446914b