### PR TITLE
Expand advanced demo with method config and validation

### DIFF
--- a/demo/advanced_features/app.py
+++ b/demo/advanced_features/app.py
@@ -1,3 +1,10 @@
+"""Advanced demo showcasing multiple flarchitect features.
+
+This example combines soft deletes, nested writes, validation, custom
+callbacks and per HTTP-method configuration.  Run this file directly and use
+the ``curl`` commands in the repository ``README`` to exercise the API.
+"""
+
 from __future__ import annotations
 
 import datetime
@@ -14,16 +21,19 @@ from flarchitect import Architect
 class BaseModel(DeclarativeBase):
     """Base model with timestamp and soft delete columns."""
 
+    # ``created`` and ``updated`` are automatically managed timestamps.
     created: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow)
     updated: Mapped[datetime.datetime] = mapped_column(DateTime, default=datetime.datetime.utcnow, onupdate=datetime.datetime.utcnow)
+    # ``deleted`` enables soft deletes when ``API_SOFT_DELETE`` is set.
     deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
 
-    def get_session(*args: Any, **kwargs: Any):
+    def get_session(*args: Any, **kwargs: Any):  # noqa: D401 - simple passthrough
         """Return the current database session."""
 
         return db.session
 
 
+# Global SQLAlchemy instance using the custom base model above.
 db = SQLAlchemy(model_class=BaseModel)
 
 
@@ -33,11 +43,38 @@ class Author(db.Model):
     __tablename__ = "author"
 
     class Meta:
+        # ``tag`` and ``tag_group`` drive grouping in the generated documentation.
         tag = "Author"
         tag_group = "People"
+        # Restrict HTTP methods to ``GET`` and ``POST`` only.
+        allowed_methods = ["GET", "POST"]
+        # Apply a rate limit specifically to author creation.
+        post_rate_limit = "5 per minute"
+        # Provide custom descriptions for documentation per HTTP method.
+        description = {
+            "GET": "Retrieve authors, optionally including soft-deleted records.",
+            "POST": "Create a new author record.",
+        }
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    # Author's name – simple string field.
     name: Mapped[str] = mapped_column(String(80))
+    # Optional contact email with validation and helpful docs metadata.
+    email: Mapped[str | None] = mapped_column(
+        String(120),
+        info={
+            "description": "Author's contact email.",
+            "format": "email",
+            "validator": "email",
+            "validator_message": "Invalid email address.",
+        },
+    )
+    # Optional website; ``format`` automatically enables URL validation.
+    website: Mapped[str | None] = mapped_column(
+        String(255),
+        info={"description": "Author website", "format": "uri"},
+    )
+    # Back-reference of books written by this author.
     books: Mapped[list[Book]] = relationship(back_populates="author")
 
 
@@ -49,12 +86,25 @@ class Book(db.Model):
     class Meta:
         tag = "Book"
         tag_group = "Content"
+        # Allow nested writes so books can be created alongside their author.
         allow_nested_writes = True
+        # Capitalise titles before saving using ``_add_callback`` below.
         add_callback = staticmethod(lambda obj, model: _add_callback(obj))
+        # Provide custom descriptions for generated documentation.
+        description = {
+            "GET": "Retrieve books with their associated authors.",
+            "POST": "Create a book and, optionally, its author in one request.",
+            "PATCH": "Update a book's details.",
+        }
+        # Demonstrate HTTP method specific configuration.
+        patch_rate_limit = "10 per minute"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    # The book's title.
     title: Mapped[str] = mapped_column(String(120))
-    author_id: Mapped[int] = mapped_column(ForeignKey("author.id"))
+    # Foreign key relationship to ``Author``.
+    # ``author_id`` is optional to support nested author creation.
+    author_id: Mapped[int | None] = mapped_column(ForeignKey("author.id"), nullable=True)
     author: Mapped[Author] = relationship(back_populates="books")
 
 
@@ -65,19 +115,11 @@ def _add_callback(obj: Book) -> Book:
     return obj
 
 
-def return_callback(model: type[BaseModel], output: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
-    """Attach a debug flag to every response.
+def dump_callback(data: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+    """Attach a debug flag to every serialised response."""
 
-    Args:
-        model: Model class being processed.
-        output: Response payload.
-
-    Returns:
-        Modified response dictionary.
-    """
-
-    output["debug"] = True
-    return {"output": output}
+    data["debug"] = True
+    return data
 
 
 def create_app() -> Flask:
@@ -97,7 +139,7 @@ def create_app() -> Flask:
         API_SOFT_DELETE=True,
         API_SOFT_DELETE_ATTRIBUTE="deleted",
         API_SOFT_DELETE_VALUES=(False, True),
-        API_RETURN_CALLBACK=return_callback,
+        API_DUMP_CALLBACK=dump_callback,
     )
 
     db.init_app(app)

--- a/tests/test_demo_advanced_features.py
+++ b/tests/test_demo_advanced_features.py
@@ -1,0 +1,45 @@
+from demo.advanced_features.app import create_app
+
+
+def _create_client():
+    """Helper to create app and test client."""
+    app = create_app()
+    return app, app.test_client()
+
+
+def test_title_capitalised_and_nested_author():
+    """Book titles should be capitalised via the add callback and nested author created."""
+    app, client = _create_client()
+    res = client.post(
+        "/api/books",
+        json={"title": "my book", "author": {"name": "alice", "email": "alice@example.com"}},
+    )
+    data = res.get_json()
+    assert res.status_code == 200
+    assert data["value"]["title"] == "My Book"
+    assert data["value"]["author"].endswith("/1")
+
+
+def test_email_validation():
+    """Invalid author email should trigger a validation error."""
+    app, client = _create_client()
+    res = client.post(
+        "/api/books",
+        json={"title": "another", "author": {"name": "bob", "email": "not-an-email"}},
+    )
+    data = res.get_json()
+    assert res.status_code == 400
+    assert "email" in data["errors"]["error"]["author"]
+
+
+def test_disallowed_method():
+    """Author PATCH endpoint is disallowed via Meta.allowed_methods."""
+    app, client = _create_client()
+    post = client.post(
+        "/api/books",
+        json={"title": "nested", "author": {"name": "carol", "email": "carol@example.com"}},
+    ).get_json()
+    author_url = post["value"]["author"]
+    author_id = author_url.rsplit("/", 1)[-1]
+    res = client.patch(f"/api/author/{author_id}", json={"name": "changed"})
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- document HTTP method-specific settings and rate limiting in advanced demo
- add email and website validation with descriptive metadata
- include dump callback and tests for nested writes and disallowed methods

## Testing
- `ruff check demo/advanced_features/app.py tests/test_demo_advanced_features.py`
- `pytest tests/test_demo_advanced_features.py`


------
https://chatgpt.com/codex/tasks/task_e_689d9e98b8088322a52b467e7f36b103