### PR TITLE
Avoid double init in demo scaffold and log docs URL

### DIFF
--- a/demo/scaffolding/load.py
+++ b/demo/scaffolding/load.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from werkzeug.serving import run_simple
+
+from flarchitect.logging import logger
+
 try:  # pragma: no cover - prefer package import
     from .module import create_app
 except ImportError:  # pragma: no cover - direct script execution
@@ -23,6 +27,17 @@ def load() -> Flask:
     return create_app()
 
 
+def app_factory() -> Flask:
+    """Create the demo application and log the documentation URL.
+
+    Returns:
+        Flask: The configured Flask application.
+    """
+    app = load()
+    docs_url = app.config.get("API_DOCUMENTATION_URL", "/docs")
+    logger.log(1, f"|Documentation available at| `http://localhost:5000{docs_url}`")
+    return app
+
+
 if __name__ == "__main__":
-    flask_app = load()
-    flask_app.run(host="0.0.0.0", port=5000, debug=True)
+    run_simple("0.0.0.0", 5000, app_factory, use_reloader=True, use_debugger=True)

--- a/tests/test_demo_scaffolding_load.py
+++ b/tests/test_demo_scaffolding_load.py
@@ -1,0 +1,12 @@
+import re
+
+from flask import Flask
+
+from demo.scaffolding.load import app_factory
+
+
+def test_app_factory_outputs_docs_url(capsys):
+    app = app_factory()
+    assert isinstance(app, Flask)
+    captured = capsys.readouterr().out
+    assert re.search(r"Documentation available at", captured)


### PR DESCRIPTION
## Summary
- avoid double initialization in scaffolding demo by running via `run_simple`
- log documentation URL when the demo app starts
- cover app factory logging with a regression test

## Testing
- `ruff check demo/scaffolding/load.py tests/test_demo_scaffolding_load.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d9c839ad083229b705f6331b9f582