### PR TITLE
Fix API spec naming and tag auth routes

### DIFF
--- a/flarchitect/core/routes.py
+++ b/flarchitect/core/routes.py
@@ -40,6 +40,7 @@ from flarchitect.specs.utils import (
     get_tag_group,
 )
 from flarchitect.utils.config_helpers import get_config_or_model_meta
+from flarchitect.utils.core_utils import convert_case
 from flarchitect.utils.general import AttributeInitializerMixin
 from flarchitect.utils.response_helpers import create_response
 from flarchitect.utils.session import get_session
@@ -65,6 +66,7 @@ def create_params_from_rule(model: DeclarativeBase, rule, schema: Schema) -> lis
         name = get_config_or_model_meta("name", model=model, output_schema=schema, default=None)
         if not name:
             name = (model or schema).__name__.replace("Schema", "").replace("schema", "")
+        name = convert_case(name, get_config_or_model_meta("API_SCHEMA_CASE", model=model, default="camel"))
 
         param_info = {
             "name": argument,
@@ -483,9 +485,13 @@ class RouteCreator(AttributeInitializerMixin):
             many=False,
             roles=True,
             group_tag="Authentication",
+            tag="Authentication",
+            summary="Authenticate user and return JWT tokens.",
             auth=False,
         )
         def login(*args, **kwargs):
+            """Authenticate a user and return JWT tokens."""
+
             data = request.get_json()
             username = data.get("username")
             password = data.get("password")
@@ -519,8 +525,12 @@ class RouteCreator(AttributeInitializerMixin):
             output_schema=None,
             many=False,
             group_tag="Authentication",
+            tag="Authentication",
+            summary="Log out current user.",
         )
         def logout(*args, **kwargs):
+            """Log out the current user."""
+
             set_current_user(None)
             return {}
 
@@ -533,18 +543,12 @@ class RouteCreator(AttributeInitializerMixin):
             output_schema=TokenSchema,
             many=False,
             group_tag="Authentication",
+            tag="Authentication",
+            summary="Refresh access token.",
             auth=False,
         )
         def refresh(*args, **kwargs):
-            """
-            Endpoint to refresh JWT access tokens using a refresh token.
-
-            Expects:
-                JSON payload with 'refresh_token'.
-
-            Returns:
-                JSON response with 'access_token' and 'refresh_token'.
-            """
+            """Refresh a JWT access token using a refresh token."""
 
             # Extract the refresh token from the request
             refresh_token = request.get_json().get("refresh_token")

--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -426,7 +426,8 @@ def register_routes_with_spec(architect: Architect, route_spec: list[dict[str, A
             if rule:
                 methods = rule.methods - {"OPTIONS", "HEAD"}
                 for http_method in methods:
-                    route_info = scrape_extra_info_from_spec_data(route_info, method=http_method)
+                    summary = route_info.get("summary")
+                    route_info = scrape_extra_info_from_spec_data(route_info, method=http_method, summary=summary)
                     path = rule.rule
 
                     output_schema = route_info.get("output_schema")

--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -636,6 +636,11 @@ def make_endpoint_description(schema: Schema, http_method: str, **kwargs) -> str
 
     parent = kwargs.get("parent")
     parent_name = parent.__name__ if parent else ""
+    if parent_name:
+        parent_name = convert_case(
+            parent_name,
+            get_config_or_model_meta("API_SCHEMA_CASE", model=parent, default="camel"),
+        )
 
     if http_method == "GET":
         if parent and many:

--- a/tests/test_make_endpoint_description.py
+++ b/tests/test_make_endpoint_description.py
@@ -1,0 +1,22 @@
+"""Tests for API endpoint description generation."""
+
+from flask import Flask
+from marshmallow import Schema
+
+from flarchitect.specs.utils import make_endpoint_description
+
+
+class UserSchema(Schema):
+    """Schema used for testing."""
+
+
+class Item:
+    """Dummy parent model used for testing."""
+
+
+def test_make_endpoint_description_parent_case() -> None:
+    """The parent and child names should respect configured casing."""
+    app = Flask(__name__)
+    with app.app_context():
+        desc = make_endpoint_description(UserSchema, "GET", parent=Item)
+    assert desc == "Get a `user` by id for a specific `item`."


### PR DESCRIPTION
## Summary
- ensure parent resources match configured case in endpoint descriptions
- tag and document JWT auth routes
- respect case for path parameter names
- support custom summaries when registering routes
- add tests for description casing and auth specs

## Testing
- `ruff check --fix flarchitect/specs/utils.py flarchitect/core/routes.py flarchitect/specs/generator.py tests/test_authentication.py tests/test_make_endpoint_description.py`
- `ruff format flarchitect/specs/utils.py flarchitect/core/routes.py flarchitect/specs/generator.py tests/test_authentication.py tests/test_make_endpoint_description.py`
- `pytest tests/test_make_endpoint_description.py tests/test_authentication.py::test_auth_routes_in_spec`
- `pytest tests/test_make_endpoint_description.py tests/test_authentication.py::test_auth_routes_in_spec`


------
https://chatgpt.com/codex/tasks/task_e_689da0bda1208322a34849037126fdc9