### PR TITLE
Avoid duplicate init under Flask reloader and expose docs URL

### DIFF
--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -15,6 +15,7 @@ from flarchitect.core.routes import (
     create_query_params_from_rule,
     find_rule_by_function,
 )
+from flarchitect.logging import logger
 from flarchitect.specs.utils import (
     _prepare_patch_schema,
     append_parameters,
@@ -299,6 +300,14 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
         get_docs._auth_disabled = True
 
         self.architect.app.register_blueprint(specification)
+
+        prefix = self.documentation_url_prefix or self._get_config("DOCUMENTATION_URL_PREFIX", "/")
+        docs_url = documentation_url if documentation_url.startswith("/") else f"/{documentation_url}"
+        full_url = f"{prefix.rstrip('/')}{docs_url}"
+        server_name = self.app.config.get("SERVER_NAME")
+        if server_name:
+            full_url = f"http://{server_name}{full_url}"
+        logger.log(1, f"API documentation available at |{full_url}|")
 
 
 def generate_swagger_spec(

--- a/tests/test_reloader_detection.py
+++ b/tests/test_reloader_detection.py
@@ -1,0 +1,44 @@
+from flask import Flask
+
+from flarchitect import Architect
+
+
+def _create_app() -> Flask:
+    """Create a minimal Flask app for testing."""
+    app = Flask(__name__)
+    app.config.update(FULL_AUTO=False, API_CREATE_DOCS=False)
+    return app
+
+
+def test_architect_skips_init_in_reloader(monkeypatch):
+    """Architect should skip initialisation in the reloader parent process."""
+    app = _create_app()
+    app.debug = True
+    monkeypatch.delenv("WERKZEUG_RUN_MAIN", raising=False)
+    architect = Architect(app)
+    assert not hasattr(architect, "app")
+
+
+def test_architect_init_runs_when_reloader_child(monkeypatch):
+    """Initialisation should run in the serving process."""
+    app = _create_app()
+    app.debug = True
+    monkeypatch.setenv("WERKZEUG_RUN_MAIN", "true")
+    with app.app_context():
+        architect = Architect(app)
+        assert architect.app is app
+
+
+def test_documentation_url_logged(monkeypatch):
+    """The documentation URL should be logged on startup."""
+    app = Flask(__name__)
+    app.config.update(FULL_AUTO=False, API_DESCRIPTION="Test API")
+    messages: list[str] = []
+
+    def fake_log(level: int, message: str) -> None:
+        messages.append(message)
+
+    monkeypatch.setattr("flarchitect.logging.logger.log", fake_log)
+    with app.app_context():
+        Architect(app)
+    assert any("|/docs|" in msg for msg in messages)


### PR DESCRIPTION
## Summary
- skip Architect setup in the Flask reloader's parent process to prevent duplicate logs
- emit the documentation URL once API docs are registered
- add tests covering reloader detection and documentation URL logging

## Testing
- `ruff check flarchitect/core/architect.py flarchitect/specs/generator.py tests/test_reloader_detection.py`
- `pytest tests/test_reloader_detection.py`
- `pytest` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689da3f05d948322870c113a23ce8478