### PR TITLE
Handle custom HTTP exceptions in API routes

### DIFF
--- a/flarchitect/core/routes.py
+++ b/flarchitect/core/routes.py
@@ -348,6 +348,14 @@ class RouteCreator(AttributeInitializerMixin):
         self.architect.app.register_blueprint(self.blueprint)
 
     def make_exception_routes(self):
+        """Register error handlers for standard and custom HTTP exceptions."""
+
+        logger.debug(
+            4,
+            "Setting up custom error handler for CustomHTTPException.",
+        )
+        self.architect.app.register_error_handler(CustomHTTPException, handle_http_exception)
+
         for code in default_exceptions:
             logger.debug(
                 4,


### PR DESCRIPTION
## Summary
- Subclass `CustomHTTPException` from `HTTPException` for better compatibility
- Register custom HTTP exception handler for API routes
- Add regression test ensuring JSON response for custom exceptions

## Testing
- `ruff check . --fix`
- `ruff format .`
- `pytest tests/test_custom_http_exception.py::test_handle_http_exception_returns_json -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dab5a47a083228fcb67ae302fdcaf