### PR TITLE
Clarify JWT secret key fallback order and add tests

### DIFF
--- a/tests/test_get_user_from_token.py
+++ b/tests/test_get_user_from_token.py
@@ -1,0 +1,35 @@
+"""Tests for secret key fallback order in ``get_user_from_token``."""
+
+from flarchitect.authentication.jwt import get_user_from_token
+
+pytest_plugins = ["tests.test_authentication"]
+
+
+def test_secret_key_argument_overrides_environment(monkeypatch, client_jwt):
+    """Explicit secret key should take precedence over environment and config values."""
+    client, access_token, _ = client_jwt
+    monkeypatch.setenv("ACCESS_SECRET_KEY", "wrong")
+    client.application.config["ACCESS_SECRET_KEY"] = "also_wrong"
+    with client.application.app_context():
+        user = get_user_from_token(access_token, secret_key="access")
+        assert user.username == "carol"
+
+
+def test_environment_fallback_used_when_no_argument(monkeypatch, client_jwt):
+    """Environment variable is used when no key is passed explicitly."""
+    client, access_token, _ = client_jwt
+    monkeypatch.setenv("ACCESS_SECRET_KEY", "access")
+    client.application.config["ACCESS_SECRET_KEY"] = "wrong"
+    with client.application.app_context():
+        user = get_user_from_token(access_token)
+        assert user.username == "carol"
+
+
+def test_config_fallback_used_last(monkeypatch, client_jwt):
+    """App config value is used when neither argument nor environment variable is set."""
+    client, access_token, _ = client_jwt
+    monkeypatch.delenv("ACCESS_SECRET_KEY", raising=False)
+    client.application.config["ACCESS_SECRET_KEY"] = "access"
+    with client.application.app_context():
+        user = get_user_from_token(access_token)
+        assert user.username == "carol"


### PR DESCRIPTION
## Summary
- clarify `get_user_from_token` secret key lookup order
- test secret key fallback logic for JWT decoding

## Testing
- `ruff check --fix flarchitect/authentication/jwt.py tests/test_get_user_from_token.py`
- `ruff format flarchitect/authentication/jwt.py tests/test_get_user_from_token.py`
- `pytest tests/test_get_user_from_token.py`


------
https://chatgpt.com/codex/tasks/task_e_689db3ecc72c8322ae6412e1cad3aae2