### PR TITLE
refactor: remove redundant config import

### DIFF
--- a/flarchitect/database/utils.py
+++ b/flarchitect/database/utils.py
@@ -70,8 +70,6 @@ def get_all_columns_and_hybrids(model: DeclarativeBase, join_models: dict[str, D
         Tuple[Dict[str, Dict[str, Union[hybrid_property, InstrumentedAttribute]]], List[DeclarativeBase]]:
         A tuple containing a dictionary of all columns and a list of all models.
     """
-    from flarchitect.utils.general import get_config_or_model_meta
-
     ignore_underscore = get_config_or_model_meta(key="API_IGNORE_UNDERSCORE_ATTRIBUTES", model=model, default=True)
     schema_case = get_config_or_model_meta(key="API_SCHEMA_CASE", model=model, default="camel")
 


### PR DESCRIPTION
## Summary
- remove redundant get_config_or_model_meta import from database utils

## Testing
- `ruff check flarchitect/database/utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689db3e366288322a59b5537eca44ba2