### PR TITLE
Fix README template path resolution

### DIFF
--- a/tests/test_readme_generation.py
+++ b/tests/test_readme_generation.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+from flarchitect.utils.general import generate_readme_html
+
+
+def test_generate_readme_html_accepts_path_object() -> None:
+    config = {"API_AUTHENTICATE": False, "API_TITLE": "Example"}
+    path = Path("flarchitect/html/base_readme.MD")
+    rendered = generate_readme_html(path, config=config, api_output_example="{}", has_rate_limiting=False)
+    assert "Example" in rendered


### PR DESCRIPTION
## Summary
- ensure README templates resolve relative to project root
- add regression test for Path input to `generate_readme_html`

## Testing
- `ruff format flarchitect/utils/general.py tests/test_readme_generation.py`
- `ruff check flarchitect/utils/general.py tests/test_readme_generation.py --fix`
- `pytest tests/test_readme_generation.py tests/test_authentication.py::test_readme_authentication_section tests/test_authentication.py::test_readme_authentication_absent_when_disabled -q`
- `pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689dc34327ac83229e68c26faa164d6e