### PR TITLE
docs: summarize authentication methods

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -6,9 +6,28 @@ Enable one or more strategies via ``API_AUTHENTICATE_METHOD``. Available
 methods are ``jwt``, ``basic``, ``api_key`` and ``custom``. Each example below
 uses the common setup defined in ``demo/authentication/app_base.py``. Runnable
 snippets demonstrating each strategy live in the project repository:
-`jwt_auth.py`_, `basic_auth.py`_ and `api_key_auth.py`_.
+`jwt_auth.py`_, `basic_auth.py`_, `api_key_auth.py`_, and `custom_auth.py`_.
 You can also protect routes based on user roles using the
 :ref:`roles-required` decorator.
+
+.. list-table:: Authentication methods
+   :header-rows: 1
+
+   * - Method
+     - Required config keys
+     - Demo
+   * - ``jwt``
+     - ``ACCESS_SECRET_KEY``, ``REFRESH_SECRET_KEY``, ``API_USER_MODEL``, ``API_USER_LOOKUP_FIELD``, ``API_CREDENTIAL_CHECK_METHOD``
+     - `jwt_auth.py`_
+   * - ``basic``
+     - ``API_USER_MODEL``, ``API_USER_LOOKUP_FIELD``, ``API_CREDENTIAL_CHECK_METHOD``
+     - `basic_auth.py`_
+   * - ``api_key``
+     - ``API_KEY_AUTH_AND_RETURN_METHOD`` (``API_CREDENTIAL_HASH_FIELD`` optional)
+     - `api_key_auth.py`_
+   * - ``custom``
+     - ``API_CUSTOM_AUTH``
+     - `custom_auth.py`_
 
 Error responses
 ---------------
@@ -269,3 +288,4 @@ Troubleshooting
 .. _jwt_auth.py: https://github.com/lewis-morris/flarchitect/blob/master/demo/authentication/jwt_auth.py
 .. _basic_auth.py: https://github.com/lewis-morris/flarchitect/blob/master/demo/authentication/basic_auth.py
 .. _api_key_auth.py: https://github.com/lewis-morris/flarchitect/blob/master/demo/authentication/api_key_auth.py
+.. _custom_auth.py: https://github.com/lewis-morris/flarchitect/blob/master/demo/authentication/custom_auth.py


### PR DESCRIPTION
## Summary
- clarify all authentication demos in docs
- add table summarizing methods, required config keys, and demo links

## Testing
- `ruff format docs/source/authentication.rst` *(fails: Expected a statement)*
- `ruff check docs/source/authentication.rst` *(fails: numerous SyntaxErrors as file is non-Python)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689dc67112448322b7126634354e8cc2