### PR TITLE
docs: document nested relationship dumping

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -41,3 +41,64 @@ Example::
 
 Clients can override ``dynamic`` dumps per request with
 ``?dump=url`` or ``?dump=json``.
+
+Nested relationship dumping
+---------------------------
+
+``API_ADD_RELATIONS`` controls whether relationship fields are included in the
+serialized response. Disable it to return only column data, or use
+``?dump_relationships=false`` on a request to temporarily suppress all
+relationships.
+
+``API_SERIALIZATION_DEPTH`` limits how many levels of related resources are
+embedded. Increasing the depth exposes deeper links or objects but may add
+overhead.
+
+For ``API_SERIALIZATION_TYPE="dynamic"``, clients can choose which
+relationships to embed by supplying a comma-separated ``join`` parameter, e.g.
+``?join=books,publisher``. Any relationships not listed are returned as URLs.
+
+Example responses
+^^^^^^^^^^^^^^^^^
+
+URL-only dump (depth ``1``)::
+
+    GET /api/authors/1
+    {
+        "id": 1,
+        "name": "Alice",
+        "books": "/api/authors/1/books"
+    }
+
+JSON dump (depth ``1``)::
+
+    GET /api/authors/1?dump=json
+    {
+        "id": 1,
+        "name": "Alice",
+        "books": [
+            {"id": 10, "title": "Example", "publisher": "/api/publishers/5"}
+        ]
+    }
+
+JSON dump (depth ``2`` with ``API_SERIALIZATION_DEPTH=2`` or ``?join=books,publisher``)::
+
+    GET /api/authors/1?dump=json
+    {
+        "id": 1,
+        "name": "Alice",
+        "books": [
+            {"id": 10, "title": "Example", "publisher": {"id": 5, "name": "ACME"}}
+        ]
+    }
+
+Hybrid dump::
+
+    GET /api/authors/1?dump=hybrid
+    {
+        "id": 1,
+        "name": "Alice",
+        "books": "/api/authors/1/books",
+        "publisher": {"id": 5, "name": "ACME"}
+    }
+


### PR DESCRIPTION
## Summary
- document API_ADD_RELATIONS and API_SERIALIZATION_DEPTH
- explain dump_relationships and join query parameters
- illustrate URL, JSON, and hybrid dumps at varying depths

## Testing
- `ruff check .`
- `ruff format docs/source/models.rst` *(fails: Failed to parse docs/source/models.rst)*
- `pytest`
- `sphinx-build -b html docs/source docs/_build` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689dc7c92fe08322aaa04516cc634da6