### PR TITLE
docs: clarify nested writes and PATCH usage

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -192,10 +192,11 @@ Nested model creation
 ---------------------
 
 Nested writes are disabled by default. Enable them globally with
-``API_ALLOW_NESTED_WRITES = True`` or per model via ``Meta.allow_nested_writes``.
+``API_ALLOW_NESTED_WRITES = True`` or per model via :attr:`Meta.allow_nested_writes`.
 Once enabled, ``AutoSchema`` can deserialize nested relationship data during
-POST or PUT requests. Include related objects under the relationship name in
-your payload::
+POST, PUT or PATCH requests. All writable methods honour
+:attr:`Meta.allow_nested_writes`. Include related objects under the relationship
+name in your payload::
 
     {
         "title": "My Book",
@@ -208,6 +209,17 @@ your payload::
             "biography": "Bio",
             "date_of_birth": "1980-01-01",
             "nationality": "US"
+        }
+    }
+
+To partially update a nested relationship, send only the fields you want to
+change in a ``PATCH`` request::
+
+    PATCH /books/1
+    {
+        "author": {
+            "id": 1,
+            "biography": "Updated bio"
         }
     }
 


### PR DESCRIPTION
## Summary
- clarify that nested writes apply to POST, PUT, and PATCH
- cross-reference `Meta.allow_nested_writes` and note all writable methods honor it
- document PATCH example for partial nested updates

## Testing
- `ruff format docs/source/advanced_configuration.rst` *(fails: Simple statements must be separated by newlines or semicolons)*
- `pytest` *(fails: 46 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689dc7c9799c8322b3af7d4f395e39c2