### PR TITLE
Fix spec URL paths in docs templates

### DIFF
--- a/flarchitect/html/apispec.html
+++ b/flarchitect/html/apispec.html
@@ -20,7 +20,7 @@
     </style>
 </head>
 <body>
-<redoc spec-url='/swagger.json'></redoc>
+<redoc spec-url="{{ url_for('specification.get_swagger_spec') }}"></redoc>
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
 </body>
 {{custom_footers|safe}}

--- a/flarchitect/html/swagger.html
+++ b/flarchitect/html/swagger.html
@@ -12,7 +12,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.14/swagger-ui-bundle.js"></script>
 <script>
     SwaggerUIBundle({
-        url: '/swagger.json',
+        url: "{{ url_for('specification.get_swagger_spec') }}",
         dom_id: '#swagger-ui'
     });
 </script>

--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -56,7 +56,7 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
     api_logo_background: str | None = None
     api_keywords: list[str] | None = None
     create_docs: bool | None = True
-    documentation_url_prefix: str | None = "/"
+    documentation_url_prefix: str | None = None
     documentation_url: str | None = "/docs"
 
     def __init__(self, app: Flask, architect: Architect, *args, **kwargs):

--- a/flarchitect/utils/general.py
+++ b/flarchitect/utils/general.py
@@ -102,6 +102,14 @@ def manual_render_absolute_template(absolute_template_path: str, **kwargs: Any) 
         template_folder, template_filename = os.path.split(template_folder)
 
     env = Environment(loader=FileSystemLoader(template_folder))
+    # ensure standard Flask globals like ``url_for`` are available
+    try:
+        from flask import url_for
+
+        env.globals.update(url_for=url_for)
+    except Exception:  # pragma: no cover - fallback when Flask not installed
+        pass
+
     template = env.get_template(template_filename)
     return template.render(**kwargs)
 

--- a/tests/test_spec_url_prefix.py
+++ b/tests/test_spec_url_prefix.py
@@ -1,0 +1,23 @@
+"""Tests ensuring spec URLs honor documentation prefix."""
+
+from demo.basic_factory.basic_factory import create_app
+
+
+def test_redoc_spec_url_respects_prefix() -> None:
+    """Redoc template should reference prefixed swagger spec."""
+    app = create_app({"DOCUMENTATION_URL_PREFIX": "/api"})
+    client = app.test_client()
+    resp = client.get("/api/docs")
+    html = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert 'spec-url="/api/swagger.json"' in html
+
+
+def test_swagger_spec_url_respects_prefix() -> None:
+    """Swagger template should reference prefixed swagger spec."""
+    app = create_app({"DOCUMENTATION_URL_PREFIX": "/api", "API_DOCS_STYLE": "swagger"})
+    client = app.test_client()
+    resp = client.get("/api/docs")
+    html = resp.get_data(as_text=True)
+    assert resp.status_code == 200
+    assert 'url: "/api/swagger.json"' in html


### PR DESCRIPTION
## Summary
- generate docs templates with dynamic `url_for` paths
- ensure Jinja templates can resolve `url_for`
- allow documentation URL prefix to be configured
- test docs pages respect prefix for spec URLs

## Testing
- `pytest tests/test_spec_url_prefix.py tests/test_docs_password.py tests/test_flask_config.py tests/test_swagger_ui.py`


------
https://chatgpt.com/codex/tasks/task_e_689dc2d105648322ace4024667ef106a