### PR TITLE
Fix inconsistent schema casing in OpenAPI generator

### DIFF
--- a/tests/test_spec_registration.py
+++ b/tests/test_spec_registration.py
@@ -29,6 +29,27 @@ def test_register_schemas_avoids_duplicates():
         register_schemas(spec, schema)
         register_schemas(spec, schema)
 
-    assert not any(
-        "has already been added to the spec" in str(w.message) for w in caught
+    assert not any("has already been added to the spec" in str(w.message) for w in caught)
+
+
+class ItemSchema(Schema):
+    id = fields.Int()
+
+
+def test_register_schemas_preserves_name_and_case():
+    app = Flask(__name__)
+    spec = APISpec(
+        title="Test",
+        version="1.0.0",
+        openapi_version="3.0.2",
+        plugins=[MarshmallowPlugin()],
     )
+    schema = ItemSchema()
+
+    with app.app_context():
+        register_schemas(spec, schema)
+        register_schemas(spec, schema)
+
+    assert schema.__class__.__name__ == "ItemSchema"
+    assert "item" in spec.components.schemas
+    assert "patchItem" in spec.components.schemas


### PR DESCRIPTION
## Summary
- ensure registered schemas honor configured case and rename existing refs
- add regression test for schema name preservation

## Testing
- `ruff check --fix flarchitect/specs/generator.py`
- `ruff format flarchitect/specs/generator.py`
- `ruff check --fix tests/test_spec_registration.py`
- `ruff format tests/test_spec_registration.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dcdc66d44832292297de5bac12549