### PR TITLE
feat(integrate-automatic-release-tool-in-workflow): chore(release): integrate semantic-release into publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,14 +1,35 @@
-# NOTE: This workflow is disabled because python-semantic-release now publishes to PyPI.
-# If you prefer to publish on GitHub Release instead of on push, delete .github/workflows/release.yml
-# and re-enable this job by removing the "if: false" and switching `on:` to "release: types: [published]".
-name: Publish to PyPI (disabled - using semantic-release)
+name: Publish to PyPI
+
 on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 jobs:
   publish:
-    if: false  # semantic-release handles publishing now
     runs-on: ubuntu-latest
     steps:
-      - run: echo "Publishing handled by semantic-release. See .github/workflows/release.yml"
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensure tags are fetched for semantic-release
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install build and semantic-release
+        run: |
+          python -m pip install --upgrade pip
+          pip install build python-semantic-release
+      - name: Semantic release version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release version --skip-build
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,8 @@ dev = [
     "twine>=4.0.2",
     "sphinx_copybutton",
     "sphinx_design",
-    "pytest-cov"
+    "pytest-cov",
+    "python-semantic-release>=10.3.1",
 ]
 
 [project.optional-dependencies]
@@ -71,7 +72,8 @@ dev = [
   "ruff",
   "isort",
   "pytest>=7.4.4",
-  "pytest-cov>=4.1.0"
+  "pytest-cov>=4.1.0",
+  "python-semantic-release>=10.3.1",
 ]
 cache = [
   "flask-caching>=2.1.0",
@@ -111,7 +113,7 @@ branch = "master"
 commit_parser = "conventional"
 tag_format = "v{version}"
 build_command = "python -m build"
-upload_to_pypi = true
+upload_to_pypi = false
 changelog_file = "CHANGELOG.md"
 
 [tool.semantic_release.remote]


### PR DESCRIPTION
## Summary
- add python-semantic-release to development dependencies and disable direct PyPI uploads
- run semantic-release versioning before building and publishing packages

## Testing
- `ruff check .`
- `isort . --check-only` *(fails: imports not sorted in existing files)*
- `black --check flarchitect/__init__.py`
- `pytest` *(fails: 47 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689dd73fbb748322b39e69e046c67a7d