### PR TITLE
feat(revise-authentication-documentation-vbgcuy): docs(auth): document role setup and link guides

### DIFF
--- a/docs/source/advanced_demo.rst
+++ b/docs/source/advanced_demo.rst
@@ -25,3 +25,6 @@ Run the demo
         -H "Content-Type: application/json" \
         -d '{"title": "my book", "author": {"name": "Alice"}}'
    curl http://localhost:5000/api/book?include_deleted=true
+
+For authentication strategies and role management, see :doc:`authentication`
+and the :ref:`defining-roles` section.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -138,3 +138,9 @@ Into this:
       ]
     }
 
+Next steps
+----------------------------------------
+
+To secure the API and define user roles, see :doc:`authentication` and the
+:ref:`defining-roles` section.
+


### PR DESCRIPTION
## Summary
- add detailed role-definition guidance to authentication docs
- cross-link role documentation from quickstart and advanced demo

## Testing
- `isort --check-only .` *(fails: imports are incorrectly sorted)*
- `black --check .` *(fails: would reformat files)*
- `ruff check .`
- `pytest` *(fails: 47 errors during collection)*
- `sphinx-build -b html docs/source docs/_build/html`

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_689dd745d53883228f71de4266575532