### PR TITLE
feat(409htq-arched/add-roles_accepted-decorator-with-tests): feat(authentication): add roles_accepted decorator

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -8,7 +8,7 @@ uses the common setup defined in ``demo/authentication/app_base.py``. Runnable
 snippets demonstrating each strategy live in the project repository:
 `jwt_auth.py`_, `basic_auth.py`_, `api_key_auth.py`_, and `custom_auth.py`_.
 You can also protect routes based on user roles using the
-:ref:`roles-required` decorator.
+:ref:`roles-required` and :ref:`roles-accepted` decorators.
 
 .. list-table:: Authentication methods
    :header-rows: 1
@@ -268,6 +268,22 @@ You can require multiple roles by passing more than one name:
 Ensure your user model exposes a list of role names, for example
 ``User.roles = ["admin", "editor"]``. If the authenticated user lacks any of
 the required roles—or if no user is authenticated—a ``403`` response is raised.
+
+
+.. _roles-accepted:
+
+Use the ``roles_accepted`` decorator to allow users with any of the listed roles to access an endpoint. The decorator checks the ``roles`` attribute on ``current_user`` and grants access if at least one role matches.
+
+.. code-block:: python
+
+   from flarchitect.authentication import roles_accepted
+
+   @app.get("/edit")
+   @roles_accepted("admin", "editor")
+   def edit_article():
+       return {"status": "ok"}
+
+If the authenticated user lacks all of the accepted roles—or if no user is authenticated—a ``403`` response is raised.
 
 Troubleshooting
 ---------------

--- a/flarchitect/authentication/__init__.py
+++ b/flarchitect/authentication/__init__.py
@@ -1,5 +1,5 @@
 """Authentication helpers and decorators."""
 
-from .roles import roles_required
+from .roles import roles_accepted, roles_required
 
-__all__ = ["roles_required"]
+__all__ = ["roles_required", "roles_accepted"]

--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -16,10 +16,7 @@ from werkzeug.routing import IntegerConverter, UnicodeConverter
 
 import flarchitect.utils
 import flarchitect.utils.decorators
-from flarchitect.database.inspections import (
-    get_model_columns,
-    get_model_relationships,
-)
+from flarchitect.database.inspections import get_model_columns, get_model_relationships
 from flarchitect.database.utils import AGGREGATE_FUNCS
 from flarchitect.logging import logger
 from flarchitect.utils.config_helpers import get_config_or_model_meta
@@ -66,10 +63,14 @@ def scrape_extra_info_from_spec_data(
             missing.append("method")
         if not function:
             missing.append("function")
-        logger.log(1, f"Missing data for documentation generation: {', '.join(missing)}")
+        logger.log(
+            1, f"Missing data for documentation generation: {', '.join(missing)}"
+        )
 
     if spec_data.get("tag") is None:
-        new_tag = get_config_or_model_meta("tag", model, output_schema, input_schema, "Unknown")
+        new_tag = get_config_or_model_meta(
+            "tag", model, output_schema, input_schema, "Unknown"
+        )
         if new_tag:
             spec_data["tag"] = new_tag
     else:
@@ -78,7 +79,9 @@ def scrape_extra_info_from_spec_data(
     if not summary and get_config_or_model_meta("AUTO_NAME_ENDPOINTS", default=True):
         schema = spec_data.get("output_schema") or spec_data.get("input_schema")
         if schema:
-            spec_data["summary"] = make_endpoint_description(schema, method, **spec_data)
+            spec_data["summary"] = make_endpoint_description(
+                schema, method, **spec_data
+            )
     else:
         spec_data["summary"] = summary
 
@@ -94,7 +97,9 @@ def scrape_extra_info_from_spec_data(
         else:
             config_val = f"{method.lower()}" + description_type
 
-        new_desc = get_config_or_model_meta(config_val, model, output_schema, input_schema, None)
+        new_desc = get_config_or_model_meta(
+            config_val, model, output_schema, input_schema, None
+        )
         if new_desc:
             spec_data[description_type] = new_desc
 
@@ -165,7 +170,9 @@ def get_param_schema(converter) -> dict[str, str]:
 #     return query_params
 
 
-def generate_delete_query_params(schema: Schema, model: DeclarativeBase) -> list[dict[str, Any]]:
+def generate_delete_query_params(
+    schema: Schema, model: DeclarativeBase
+) -> list[dict[str, Any]]:
     """Helper function to generate query parameters for DELETE method.
 
     Args:
@@ -177,7 +184,9 @@ def generate_delete_query_params(schema: Schema, model: DeclarativeBase) -> list
     """
     query_params = []
 
-    if get_config_or_model_meta("API_ALLOW_CASCADE_DELETE", getattr(schema.Meta, "model", None), default=True):
+    if get_config_or_model_meta(
+        "API_ALLOW_CASCADE_DELETE", getattr(schema.Meta, "model", None), default=True
+    ):
         query_params.append(
             {
                 "name": "cascade_delete",
@@ -189,7 +198,9 @@ def generate_delete_query_params(schema: Schema, model: DeclarativeBase) -> list
     return query_params
 
 
-def generate_get_query_params(schema: Schema, model: DeclarativeBase) -> list[dict[str, Any]]:
+def generate_get_query_params(
+    schema: Schema, model: DeclarativeBase
+) -> list[dict[str, Any]]:
     """Helper function to generate query parameters for GET method.
 
     Args:
@@ -231,7 +242,9 @@ def generate_get_query_params(schema: Schema, model: DeclarativeBase) -> list[di
     return query_params
 
 
-def generate_additional_query_params(methods: set, schema: Schema, model: DeclarativeBase) -> list[dict[str, Any]]:
+def generate_additional_query_params(
+    methods: set, schema: Schema, model: DeclarativeBase
+) -> list[dict[str, Any]]:
     """Helper function to generate additional query parameters.
 
     Args:
@@ -274,7 +287,8 @@ def _add_request_body_to_spec_template(
     """
     case = get_config_or_model_meta("API_SCHEMA_CASE", model=model, default="camel")
     name = convert_case(
-        ("patch_" if http_method == "PATCH" else "") + input_schema.__name__.replace("Schema", ""),
+        ("patch_" if http_method == "PATCH" else "")
+        + input_schema.__name__.replace("Schema", ""),
         case,
     )
 
@@ -289,7 +303,9 @@ def _add_request_body_to_spec_template(
     }
 
 
-def _add_response_to_spec_template(spec_template: dict[str, Any], output_schema: Schema):
+def _add_response_to_spec_template(
+    spec_template: dict[str, Any], output_schema: Schema
+):
     """Helper function to add a response to the spec template.
 
     Args:
@@ -315,7 +331,9 @@ def _add_response_to_spec_template(spec_template: dict[str, Any], output_schema:
     )
 
 
-def _initialize_base_responses(method: str, many: bool, error_responses: list[int]) -> dict[str, dict[str, Any]]:
+def _initialize_base_responses(
+    method: str, many: bool, error_responses: list[int]
+) -> dict[str, dict[str, Any]]:
     """Helper function to initialize base responses.
 
     Args:
@@ -331,10 +349,18 @@ def _initialize_base_responses(method: str, many: bool, error_responses: list[in
     if 500 in error_responses or not error_responses:
         responses["500"] = {"description": HTTP_STATUS_CODES.get(500)}
 
-    if method != "POST" and not many and (404 in error_responses or not error_responses):
+    if (
+        method != "POST"
+        and not many
+        and (404 in error_responses or not error_responses)
+    ):
         responses["404"] = {"description": HTTP_STATUS_CODES.get(404)}
 
-    if method == "DELETE" and not many and (409 in error_responses or not error_responses):
+    if (
+        method == "DELETE"
+        and not many
+        and (409 in error_responses or not error_responses)
+    ):
         responses["409"] = {"description": HTTP_STATUS_CODES.get(409)}
 
     return responses
@@ -420,11 +446,15 @@ def get_template_data_for_model(schema: Schema) -> dict[str, Any] | None:
         base_fields = get_model_columns(base_model)
 
         model_relationships = get_model_relationships(base_model)
-        model_relationship_names = [convert_case(x.__name__, schema_case) for x in model_relationships]
+        model_relationship_names = [
+            convert_case(x.__name__, schema_case) for x in model_relationships
+        ]
 
         if model_relationships:
             relationship_fields = get_model_columns(model_relationships[0])
-            relationship_resource = convert_case(model_relationships[0].__name__, schema_case)
+            relationship_resource = convert_case(
+                model_relationships[0].__name__, schema_case
+            )
         else:
             relationship_fields = []
             relationship_resource = None
@@ -442,7 +472,9 @@ def get_template_data_for_model(schema: Schema) -> dict[str, Any] | None:
     return None
 
 
-def generate_example_values(now: datetime, yesterday: datetime, day_before_yesterday: datetime) -> dict[str, list[str]]:
+def generate_example_values(
+    now: datetime, yesterday: datetime, day_before_yesterday: datetime
+) -> dict[str, list[str]]:
     """Helper function to generate example values for filter examples.
 
     Args:
@@ -542,7 +574,9 @@ def generate_operator_examples(
         if col_type in operators:
             chosen_operator = random.choice(operators[col_type])
             if chosen_operator in ["__in", "__nin"]:
-                chosen_values = ", ".join(random.choices(example_values.get(col_type, ["value"]), k=3))
+                chosen_values = ", ".join(
+                    random.choices(example_values.get(col_type, ["value"]), k=3)
+                )
                 examples.append(f"{column}{chosen_operator}=({chosen_values})")
             else:
                 chosen_value = random.choice(example_values.get(col_type, ["value"]))
@@ -551,7 +585,9 @@ def generate_operator_examples(
     return examples
 
 
-def get_table_name(index: int, resource_name: str, fields: list[str], example_table: list[str]) -> str:
+def get_table_name(
+    index: int, resource_name: str, fields: list[str], example_table: list[str]
+) -> str:
     """Helper function to generate table names for field examples.
 
     Args:
@@ -573,7 +609,11 @@ def get_table_name(index: int, resource_name: str, fields: list[str], example_ta
         current_fields = []
         for _ in range(5):
             table_choice = random.choice([resource_name, "OtherTable"])
-            field_choice = random.choice(temp_fields) if table_choice == resource_name else random.choice(example_table)
+            field_choice = (
+                random.choice(temp_fields)
+                if table_choice == resource_name
+                else random.choice(example_table)
+            )
             current_fields.append(f"{table_choice}.{field_choice}")
 
     return "fields=" + ",".join(current_fields)
@@ -595,7 +635,11 @@ def _prepare_patch_schema(input_schema: Schema | None) -> Schema | None:
     class_fields = {}
 
     # Iterate over all fields in the input schema
-    items = input_schema.fields.items() if hasattr(input_schema, "fields") else input_schema().fields.items()
+    items = (
+        input_schema.fields.items()
+        if hasattr(input_schema, "fields")
+        else input_schema().fields.items()
+    )
 
     for field_name, field_obj in items:
         # Deepcopy the field to avoid mutating the original field
@@ -641,7 +685,9 @@ def make_endpoint_description(schema: Schema, http_method: str, **kwargs) -> str
     many = kwargs.get("multiple")
     model = getattr(schema, "get_model", lambda: None)()
     name = (kwargs.get("model") or model or schema).__name__.replace("Schema", "")
-    name = convert_case(name, get_config_or_model_meta("API_SCHEMA_CASE", model=model, default="camel"))
+    name = convert_case(
+        name, get_config_or_model_meta("API_SCHEMA_CASE", model=model, default="camel")
+    )
 
     parent = kwargs.get("parent")
     parent_name = parent.__name__ if parent else ""
@@ -683,7 +729,11 @@ def generate_fields_description(schema: Schema) -> str:
     if callable(schema):
         schema = schema()
 
-    fields = [(k, v.metadata.get("description", "")) for k, v in schema.fields.items() if v and v.dump_only is False and not isinstance(v, RelatedList | Related)]
+    fields = [
+        (k, v.metadata.get("description", ""))
+        for k, v in schema.fields.items()
+        if v and v.dump_only is False and not isinstance(v, RelatedList | Related)
+    ]
 
     if hasattr(schema, "Meta") and hasattr(schema.Meta, "model"):
         resource_name = schema.Meta.model.__name__
@@ -693,7 +743,9 @@ def generate_fields_description(schema: Schema) -> str:
             "OtherTable.id",
             "OtherTable.email",
         ]
-        example_fields = [get_table_name(i, resource_name, fields, example_table) for i in range(3)]
+        example_fields = [
+            get_table_name(i, resource_name, fields, example_table) for i in range(3)
+        ]
 
         full_path = os.path.join(html_path, "redoc_templates/fields.html")
         schema_name = endpoint_namer(schema.Meta.model)
@@ -751,7 +803,9 @@ def generate_filter_examples(schema: Schema) -> str:
 
     full_path = os.path.join(html_path, "redoc_templates/filters.html")
 
-    return manual_render_absolute_template(full_path, examples=[example_one, example_two])
+    return manual_render_absolute_template(
+        full_path, examples=[example_one, example_two]
+    )
 
 
 def convert_path_to_openapi(path: str) -> str:
@@ -818,7 +872,9 @@ def append_parameters(
     Returns:
         None
     """
-    flarchitect.utils.general.html_path = current_app.extensions["flarchitect"].get_templates_path()
+    flarchitect.utils.general.html_path = current_app.extensions[
+        "flarchitect"
+    ].get_templates_path()
 
     spec_template.setdefault("parameters", []).extend(path_params + query_params)
     rate_limit = get_config_or_model_meta(
@@ -831,15 +887,24 @@ def append_parameters(
 
     if rate_limit:
         description = spec_template.get("description", "")
-        spec_template["description"] = f"{description}\n**Rate Limited** - requests on this endpoint are limited to `{rate_limit}`."
+        spec_template["description"] = (
+            f"{description}\n**Rate Limited** - requests on this endpoint are limited to `{rate_limit}`."
+        )
 
     if input_schema:
-        _add_request_body_to_spec_template(spec_template, http_method, input_schema, model)
+        _add_request_body_to_spec_template(
+            spec_template, http_method, input_schema, model
+        )
 
     if output_schema:
         _add_response_to_spec_template(spec_template, output_schema)
 
-    if http_method == "GET" and model and many and get_config_or_model_meta("API_ALLOW_FILTERS", model=model, default=True):
+    if (
+        http_method == "GET"
+        and model
+        and many
+        and get_config_or_model_meta("API_ALLOW_FILTERS", model=model, default=True)
+    ):
         spec_template["parameters"].append(
             {
                 "name": "filters",
@@ -850,7 +915,9 @@ def append_parameters(
         )
 
         template_data = get_template_data_for_model(output_schema)
-        spec_template["parameters"].extend(make_endpoint_params_description(output_schema, template_data))
+        spec_template["parameters"].extend(
+            make_endpoint_params_description(output_schema, template_data)
+        )
 
     add_auth_to_spec(model, spec_template)
 
@@ -866,7 +933,9 @@ def add_auth_to_spec(model: DeclarativeBase, spec_template: dict[str, Any]):
         None
     """
     auth_on = get_config_or_model_meta("API_AUTHENTICATE", model=model, default=False)
-    auth_type = get_config_or_model_meta("API_AUTHENTICATE_METHOD", model=model, default=None)
+    auth_type = get_config_or_model_meta(
+        "API_AUTHENTICATE_METHOD", model=model, default=None
+    )
 
     if not auth_on:
         return
@@ -901,7 +970,9 @@ def add_auth_to_spec(model: DeclarativeBase, spec_template: dict[str, Any]):
         }
 
 
-def make_endpoint_params_description(schema: Schema, data: dict[str, Any]) -> list[dict[str, Any]]:
+def make_endpoint_params_description(
+    schema: Schema, data: dict[str, Any]
+) -> list[dict[str, Any]]:
     """Generates endpoint parameters description from a schema for the API docs.
 
     Args:
@@ -913,7 +984,9 @@ def make_endpoint_params_description(schema: Schema, data: dict[str, Any]) -> li
     """
     params = []
 
-    if get_config_or_model_meta("API_ALLOW_SELECT_FIELDS", getattr(schema.Meta, "model", None), default=True):
+    if get_config_or_model_meta(
+        "API_ALLOW_SELECT_FIELDS", getattr(schema.Meta, "model", None), default=True
+    ):
         params.append(
             {
                 "name": "fields",
@@ -923,43 +996,59 @@ def make_endpoint_params_description(schema: Schema, data: dict[str, Any]) -> li
             }
         )
 
-    if get_config_or_model_meta("API_ALLOW_ORDER_BY", getattr(schema.Meta, "model", None), default=True):
+    if get_config_or_model_meta(
+        "API_ALLOW_ORDER_BY", getattr(schema.Meta, "model", None), default=True
+    ):
         params.append(
             {
                 "name": "order by",
                 "in": "query",
                 "schema": {"type": "string"},
-                "description": generate_x_description(data, "redoc_templates/order.html"),
+                "description": generate_x_description(
+                    data, "redoc_templates/order.html"
+                ),
             }
         )
 
-    if get_config_or_model_meta("API_ALLOW_JOIN", getattr(schema.Meta, "model", None), default=False):
+    if get_config_or_model_meta(
+        "API_ALLOW_JOIN", getattr(schema.Meta, "model", None), default=False
+    ):
         params.append(
             {
                 "name": "join",
                 "in": "query",
                 "schema": {"type": "string"},
-                "description": generate_x_description(data, "redoc_templates/joins.html"),
+                "description": generate_x_description(
+                    data, "redoc_templates/joins.html"
+                ),
             }
         )
 
-    if get_config_or_model_meta("API_ALLOW_GROUPBY", getattr(schema.Meta, "model", None), default=False):
+    if get_config_or_model_meta(
+        "API_ALLOW_GROUPBY", getattr(schema.Meta, "model", None), default=False
+    ):
         params.append(
             {
                 "name": "groupby",
                 "in": "query",
                 "schema": {"type": "string"},
-                "description": generate_x_description(data, "redoc_templates/group.html"),
+                "description": generate_x_description(
+                    data, "redoc_templates/group.html"
+                ),
             }
         )
 
-    if get_config_or_model_meta("API_ALLOW_AGGREGATION", getattr(schema.Meta, "model", None), default=False):
+    if get_config_or_model_meta(
+        "API_ALLOW_AGGREGATION", getattr(schema.Meta, "model", None), default=False
+    ):
         params.append(
             {
                 "name": "aggregation",
                 "in": "query",
                 "schema": {"type": "string"},
-                "description": generate_x_description(data, "redoc_templates/aggregate.html"),
+                "description": generate_x_description(
+                    data, "redoc_templates/aggregate.html"
+                ),
             }
         )
 
@@ -977,11 +1066,17 @@ def handle_authorization(f: Callable, spec_template: dict[str, Any]):
         None
     """
     required_roles = None
+    roles_label = None
 
     if hasattr(f, "_decorators"):
         for decorator in f._decorators:
-            if decorator.__name__ == "roles_required":
+            if decorator.__name__ in {"roles_required", "roles_accepted"}:
                 required_roles = decorator._args
+                roles_label = (
+                    "Roles required"
+                    if decorator.__name__ == "roles_required"
+                    else "Roles accepted"
+                )
                 spec_template["parameters"].append(
                     {
                         "name": "Authorization",
@@ -993,9 +1088,11 @@ def handle_authorization(f: Callable, spec_template: dict[str, Any]):
                 )
                 break
 
-    if required_roles:
+    if required_roles and roles_label:
         roles_desc = ", ".join(required_roles)
-        spec_template["responses"]["401"]["description"] += f" Roles required: {roles_desc}."
+        spec_template["responses"]["401"][
+            "description"
+        ] += f" {roles_label}: {roles_desc}."
 
 
 def get_openapi_meta_data(field_obj: fields.Field) -> dict[str, Any]:
@@ -1010,13 +1107,23 @@ def get_openapi_meta_data(field_obj: fields.Field) -> dict[str, Any]:
     openapi_type_info = {}
     field_type = type(field_obj)
 
-    if hasattr(field_obj, "parent") and hasattr(field_obj.parent, "Meta") and hasattr(field_obj.parent.Meta, "model"):
-        openapi_type_info = get_description_and_example_add(openapi_type_info, field_obj)
+    if (
+        hasattr(field_obj, "parent")
+        and hasattr(field_obj.parent, "Meta")
+        and hasattr(field_obj.parent.Meta, "model")
+    ):
+        openapi_type_info = get_description_and_example_add(
+            openapi_type_info, field_obj
+        )
 
     openapi_type_info["type"] = type_mapping.get(field_type, "string")
 
     if field_type in [fields.DateTime, fields.Date, fields.Time]:
-        openapi_type_info["format"] = "date-time" if field_type == fields.DateTime else field_type.__name__.lower()
+        openapi_type_info["format"] = (
+            "date-time"
+            if field_type == fields.DateTime
+            else field_type.__name__.lower()
+        )
 
     if field_type == fields.Function:
         openapi_type_info["format"] = "uri"
@@ -1028,7 +1135,9 @@ def get_openapi_meta_data(field_obj: fields.Field) -> dict[str, Any]:
     if field_type in [Nested, Related, RelatedList]:
         related_schema_name = get_related_schema_name(field_obj, field_type)
         if related_schema_name:
-            openapi_type_info = handle_nested_related_fields(field_obj, field_type, related_schema_name, openapi_type_info)
+            openapi_type_info = handle_nested_related_fields(
+                field_obj, field_type, related_schema_name, openapi_type_info
+            )
 
     return openapi_type_info
 
@@ -1071,13 +1180,17 @@ def handle_nested_related_fields(
     """
     if field_obj.many or field_type == RelatedList:
         openapi_type_info["type"] = "array"
-        openapi_type_info["items"] = {"$ref": f"#/components/schemas/{related_schema_name}"}
+        openapi_type_info["items"] = {
+            "$ref": f"#/components/schemas/{related_schema_name}"
+        }
     else:
         openapi_type_info["$ref"] = f"#/components/schemas/{related_schema_name}"
     return openapi_type_info
 
 
-def get_description_and_example_add(openapi_type_info: dict[str, Any], field_obj: fields.Field) -> dict[str, Any]:
+def get_description_and_example_add(
+    openapi_type_info: dict[str, Any], field_obj: fields.Field
+) -> dict[str, Any]:
     """Add description and example to the OpenAPI metadata from the model field.
 
     Args:
@@ -1134,7 +1247,11 @@ def get_description(kwargs: dict[str, Any]) -> str:
         parent = kwargs["parent_model"]
         return f"Get multiple `{name}` records from the database based on the parent {endpoint_namer(parent)} id"
 
-    description = getattr(model.Meta, "description", {}).get(method) if hasattr(model, "Meta") else None
+    description = (
+        getattr(model.Meta, "description", {}).get(method)
+        if hasattr(model, "Meta")
+        else None
+    )
     if description:
         return description
 


### PR DESCRIPTION
## Summary
- add `roles_accepted` decorator allowing access with any matching role
- document and expose `roles_accepted` alongside `roles_required`
- cover role acceptance in OpenAPI generation and tests

## Testing
- `python -m isort flarchitect/authentication/roles.py flarchitect/authentication/__init__.py flarchitect/specs/utils.py tests/test_roles_required.py`
- `python -m black flarchitect/authentication/roles.py flarchitect/authentication/__init__.py flarchitect/specs/utils.py tests/test_roles_required.py`
- `python -m ruff check flarchitect/authentication/roles.py flarchitect/authentication/__init__.py flarchitect/specs/utils.py tests/test_roles_required.py`
- `pytest tests/test_roles_required.py`


------
https://chatgpt.com/codex/tasks/task_e_689dd74aa12083229ee02cc4be41bf2c