### PR TITLE
feat(add-docstring-and-return-type-hint-for-create_pagination_def): docs(database): document pagination defaults helper

### DIFF
--- a/flarchitect/database/utils.py
+++ b/flarchitect/database/utils.py
@@ -85,7 +85,14 @@ def get_all_columns_and_hybrids(model: DeclarativeBase, join_models: dict[str, D
     return all_columns, all_models
 
 
-def create_pagination_defaults():
+def create_pagination_defaults() -> tuple[dict[str, int], dict[str, int]]:
+    """Assemble default and maximum pagination limits and return both dictionaries.
+
+    Returns:
+        tuple[dict[str, int], dict[str, int]]: Default pagination values and
+        their maximum allowable limits.
+    """
+
     PAGINATION_DEFAULTS = {
         "page": 1,
         "limit": get_config_or_model_meta("API_PAGINATION_SIZE_DEFAULT", default=20),


### PR DESCRIPTION
## Summary
- document pagination defaults helper

## Testing
- `isort --profile black --line-length 200 flarchitect/database/utils.py`
- `black --line-length 200 --skip-string-normalization flarchitect/database/utils.py`
- `ruff check flarchitect/database/utils.py`
- `pytest` *(fails: 48 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689dde537aa083228ffd32ed585acea6