### PR TITLE
feat(remove-get_session-method-from-basemodel): refactor(quickstart): remove BaseModel get_session

### DIFF
--- a/demo/quickstart/load.py
+++ b/demo/quickstart/load.py
@@ -8,12 +8,11 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from flarchitect import Architect
 
 
-# Create a base model that all models will inherit from. This is a requirement for the auto api creator to work.
-# Don't, however, add to any of your models when using flask-sqlalchemy, instead, inherit from `db.model` as you
-# would normally.
+# Create a base model that all models will inherit from. This is a requirement for the auto
+# API creator to work. Don't, however, add to any of your models when using
+# flask-sqlalchemy; instead, inherit from `db.model` as you would normally.
 class BaseModel(DeclarativeBase):
-    def get_session(*args):
-        return db.session
+    """Base declarative model for all SQLAlchemy models."""
 
 
 # Create a new flask app
@@ -33,6 +32,8 @@ app.config["API_BASE_MODEL"] = db.Model
 
 # Create a new model that inherits from db.Model
 class Author(db.Model):
+    """Model representing an author."""
+
     __tablename__ = "author"
 
     class Meta:


### PR DESCRIPTION
## Summary
- rely on default session resolution by dropping BaseModel.get_session
- document BaseModel and Author models

## Testing
- `isort demo/quickstart/load.py`
- `black demo/quickstart/load.py`
- `ruff check demo/quickstart/load.py`
- `python - <<'PY'
import demo.quickstart.load
print('loaded')
PY`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

## Labels
- refactor

------
https://chatgpt.com/codex/tasks/task_e_689dde7b06048322a5a3b90d4fb2771f