### PR TITLE
feat(add-demo-for-api_field_case-styles): docs(demo): add camel case field casing demo

### DIFF
--- a/demo/field_case/README.md
+++ b/demo/field_case/README.md
@@ -1,0 +1,33 @@
+# Field Casing Demo
+
+Demonstrates how `API_FIELD_CASE="camel"` converts SQLAlchemy model attributes
+from snake_case to camelCase in both requests and responses.
+
+## Running the demo
+
+```bash
+python demo/field_case/app.py
+```
+
+## Sample request
+
+```bash
+curl -X POST http://localhost:5000/api/people \
+     -H "Content-Type: application/json" \
+     -d '{"firstName": "Alice", "lastName": "Smith"}'
+```
+
+### Sample response
+
+```json
+{
+  "data": {
+    "id": 1,
+    "firstName": "Alice",
+    "lastName": "Smith"
+  }
+}
+```
+
+The underlying SQLAlchemy model keeps snake_case attribute names while the API
+communicates using camelCase keys.

--- a/demo/field_case/__init__.py
+++ b/demo/field_case/__init__.py
@@ -1,0 +1,5 @@
+"""Demo application showcasing API field casing options."""
+
+from .app import Person, create_app, db
+
+__all__ = ["create_app", "db", "Person"]

--- a/demo/field_case/app.py
+++ b/demo/field_case/app.py
@@ -1,0 +1,74 @@
+"""Demo API showcasing custom field name casing."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from flarchitect import Architect
+
+
+class BaseModel(DeclarativeBase):
+    """Base model providing a session accessor for flarchitect."""
+
+    def get_session(*args: Any, **kwargs: Any) -> Any:
+        """Return the current database session."""
+
+        return db.session
+
+
+# SQLAlchemy instance using the custom base model above.
+db = SQLAlchemy(model_class=BaseModel)
+
+
+class Person(db.Model):
+    """Simple person model used in the field case demo."""
+
+    __tablename__ = "people"
+
+    class Meta:
+        """Expose the model through the API and group it under ``Person``."""
+
+        tag = "Person"
+        tag_group = "Demo"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    first_name: Mapped[str] = mapped_column(String(80), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(80), nullable=False)
+
+
+def create_app(config: dict[str, Any] | None = None) -> Flask:
+    """Build and configure the field casing demo application.
+
+    Args:
+        config: Optional mapping to override default configuration values.
+
+    Returns:
+        Configured Flask application exposing camelCased fields.
+    """
+
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        API_TITLE="Field Casing API",
+        API_VERSION="1.0",
+        API_BASE_MODEL=db.Model,
+        API_FIELD_CASE="camel",
+    )
+    if config:
+        app.config.update(config)
+
+    db.init_app(app)
+    with app.app_context():
+        db.create_all()
+        Architect(app)
+
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution helper
+    create_app().run(debug=True)


### PR DESCRIPTION
## Summary
- demonstrate `API_FIELD_CASE="camel"` through new field casing demo
- document camelCase request/response behavior in demo README

## Testing
- `isort demo/field_case/app.py demo/field_case/__init__.py`
- `black demo/field_case/app.py demo/field_case/__init__.py`
- `ruff check demo/field_case/app.py demo/field_case/__init__.py --fix`
- `pytest tests/test_demo_validators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689dde8001c48322a20b8f853e059a5b