### PR TITLE
fix(jwt): validate secret keys before decoding

### DIFF
--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -217,7 +217,10 @@ def test_auth_routes_in_spec() -> None:
         spec = client.get("/swagger.json").get_json()
 
     assert spec["paths"]["/auth/login"]["post"]["tags"] == ["Authentication"]
-    assert spec["paths"]["/auth/login"]["post"]["summary"] == "Authenticate user and return JWT tokens."
+    assert (
+        spec["paths"]["/auth/login"]["post"]["summary"]
+        == "Authenticate user and return JWT tokens."
+    )
     assert spec["paths"]["/auth/logout"]["post"]["tags"] == ["Authentication"]
     assert spec["paths"]["/auth/logout"]["post"]["summary"] == "Log out current user."
     assert spec["paths"]["/auth/refresh"]["post"]["tags"] == ["Authentication"]
@@ -299,7 +302,9 @@ def test_basic_success_and_failure(client_basic: FlaskClient) -> None:
     assert get_current_user() is None
 
     bad_credentials = base64.b64encode(b"alice:wrong").decode("utf-8")
-    resp_bad = client_basic.get("/basic", headers={"Authorization": f"Basic {bad_credentials}"})
+    resp_bad = client_basic.get(
+        "/basic", headers={"Authorization": f"Basic {bad_credentials}"}
+    )
     assert resp_bad.status_code == 401
     assert get_current_user() is None
 
@@ -308,12 +313,16 @@ def test_basic_login(client_basic: FlaskClient) -> None:
     """Validate basic login endpoint with correct and incorrect credentials."""
 
     credentials = base64.b64encode(b"alice:wonderland").decode("utf-8")
-    resp = client_basic.post("/auth/login", headers={"Authorization": f"Basic {credentials}"})
+    resp = client_basic.post(
+        "/auth/login", headers={"Authorization": f"Basic {credentials}"}
+    )
     assert resp.status_code == 200
     assert resp.get_json()["value"]["username"] == "alice"
 
     bad_credentials = base64.b64encode(b"alice:bad").decode("utf-8")
-    resp_bad = client_basic.post("/auth/login", headers={"Authorization": f"Basic {bad_credentials}"})
+    resp_bad = client_basic.post(
+        "/auth/login", headers={"Authorization": f"Basic {bad_credentials}"}
+    )
     assert resp_bad.status_code == 401
 
 
@@ -334,11 +343,15 @@ def test_api_key_success_and_failure(client_api_key: FlaskClient) -> None:
 def test_api_key_login(client_api_key: FlaskClient) -> None:
     """Validate API key login endpoint."""
 
-    resp = client_api_key.post("/auth/login", headers={"Authorization": "Api-Key secret"})
+    resp = client_api_key.post(
+        "/auth/login", headers={"Authorization": "Api-Key secret"}
+    )
     assert resp.status_code == 200
     assert resp.get_json()["value"]["username"] == "bob"
 
-    resp_bad = client_api_key.post("/auth/login", headers={"Authorization": "Api-Key wrong"})
+    resp_bad = client_api_key.post(
+        "/auth/login", headers={"Authorization": "Api-Key wrong"}
+    )
     assert resp_bad.status_code == 401
 
 
@@ -354,7 +367,9 @@ def test_jwt_success_and_failure(client_jwt: tuple[FlaskClient, str, str]) -> No
 
     new_access_token, user = refresh_access_token(refresh_token)
     assert user.username == "carol"
-    resp_new = client.get("/jwt", headers={"Authorization": f"Bearer {new_access_token}"})
+    resp_new = client.get(
+        "/jwt", headers={"Authorization": f"Bearer {new_access_token}"}
+    )
     assert resp_new.status_code == 200
     assert resp_new.get_json()["value"]["username"] == "carol"
     assert get_current_user() is None
@@ -366,6 +381,25 @@ def test_jwt_success_and_failure(client_jwt: tuple[FlaskClient, str, str]) -> No
     with pytest.raises(CustomHTTPException):
         refresh_access_token(refresh_token)
     assert get_current_user() is None
+
+
+def test_refresh_access_token_missing_key(
+    monkeypatch, client_jwt: tuple[FlaskClient, str, str]
+) -> None:
+    """``refresh_access_token`` raises when ``REFRESH_SECRET_KEY`` is absent."""
+
+    client, _, refresh_token = client_jwt
+    monkeypatch.delenv("REFRESH_SECRET_KEY", raising=False)
+    client.application.config.pop("REFRESH_SECRET_KEY", None)
+
+    with (
+        client.application.app_context(),
+        pytest.raises(CustomHTTPException) as exc_info,
+    ):
+        refresh_access_token(refresh_token)
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.reason == "REFRESH_SECRET_KEY missing"
 
 
 def test_jwt_expiry_config(client_jwt: tuple[FlaskClient, str, str]) -> None:
@@ -381,8 +415,16 @@ def test_jwt_expiry_config(client_jwt: tuple[FlaskClient, str, str]) -> None:
         refresh = generate_refresh_token(user)
         access_payload = decode_token(access, app.config["ACCESS_SECRET_KEY"])
         refresh_payload = decode_token(refresh, app.config["REFRESH_SECRET_KEY"])
-        access_delta = datetime.datetime.fromtimestamp(access_payload["exp"], datetime.timezone.utc) - datetime.datetime.fromtimestamp(access_payload["iat"], datetime.timezone.utc)
-        refresh_delta = datetime.datetime.fromtimestamp(refresh_payload["exp"], datetime.timezone.utc) - datetime.datetime.fromtimestamp(refresh_payload["iat"], datetime.timezone.utc)
+        access_delta = datetime.datetime.fromtimestamp(
+            access_payload["exp"], datetime.timezone.utc
+        ) - datetime.datetime.fromtimestamp(
+            access_payload["iat"], datetime.timezone.utc
+        )
+        refresh_delta = datetime.datetime.fromtimestamp(
+            refresh_payload["exp"], datetime.timezone.utc
+        ) - datetime.datetime.fromtimestamp(
+            refresh_payload["iat"], datetime.timezone.utc
+        )
         assert access_delta == datetime.timedelta(minutes=1)
         assert refresh_delta == datetime.timedelta(minutes=2)
 


### PR DESCRIPTION
## Summary
- ensure required JWT secret keys exist before decoding tokens
- simplify refresh token flow by removing dead payload check
- add tests for missing ACCESS_SECRET_KEY and REFRESH_SECRET_KEY scenarios

## Testing
- `ruff check --fix flarchitect/authentication/jwt.py tests/test_authentication.py tests/test_get_user_from_token.py`
- `isort flarchitect/authentication/jwt.py tests/test_authentication.py tests/test_get_user_from_token.py`
- `black flarchitect/authentication/jwt.py tests/test_authentication.py tests/test_get_user_from_token.py`
- `pytest tests/test_authentication.py tests/test_get_user_from_token.py`


------
https://chatgpt.com/codex/tasks/task_e_689dde939134832292f6260374654dad