### PR TITLE
fix(authentication): clear user context after request

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -239,6 +239,21 @@ Clients can then call your API with whatever headers your function expects:
 
 See ``demo/authentication/custom_auth.py`` for this approach in context.
 
+Clearing the user context
+-------------------------
+
+flarchitect ensures the ``current_user`` does not leak between requests.
+During authentication setup a Flask ``teardown_request`` handler calls
+``set_current_user(None)`` after each request. If you integrate
+authentication manually, register the handler with
+``register_user_teardown(app)``:
+
+.. code-block:: python
+
+   from flarchitect.authentication.user import register_user_teardown
+
+   register_user_teardown(app)
+
 .. _roles-required:
 
 Role-based access

--- a/flarchitect/authentication/user.py
+++ b/flarchitect/authentication/user.py
@@ -8,6 +8,7 @@ interface for accessing the current user while remaining thread-safe.
 from contextvars import ContextVar
 from typing import Any
 
+from flask import Flask
 from werkzeug.local import LocalProxy
 
 # Create a ContextVar to store the current user
@@ -36,6 +37,34 @@ def get_current_user() -> Any | None:
     """
 
     return _current_user_ctx_var.get()
+
+
+def register_user_teardown(app: Flask) -> None:
+    """Register a teardown handler to clear the current user.
+
+    Args:
+        app (Flask): The Flask application instance.
+
+    Returns:
+        None: This function does not return a value.
+    """
+
+    if getattr(app, "_flarchitect_user_teardown_registered", False):
+        return
+    app._flarchitect_user_teardown_registered = True
+
+    @app.teardown_request
+    def _clear_current_user(exception: BaseException | None = None) -> None:
+        """Remove the user from context after each request.
+
+        Args:
+            exception (BaseException | None): Exception during the request, if any.
+
+        Returns:
+            None: Flask ignores the return value of teardown callbacks.
+        """
+
+        set_current_user(None)
 
 
 # Create a LocalProxy to access the current user easily

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -1,0 +1,28 @@
+"""Tests for clearing user context after requests."""
+
+from flask import Flask
+
+from flarchitect.authentication.user import (
+    get_current_user,
+    register_user_teardown,
+    set_current_user,
+)
+
+
+def test_register_user_teardown_clears_context() -> None:
+    """Teardown handler removes the current user after each request."""
+    app = Flask(__name__)
+    register_user_teardown(app)
+
+    @app.route("/")
+    def index() -> str:
+        set_current_user("alice")
+        return "ok"
+
+    client = app.test_client()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert get_current_user() is None
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert get_current_user() is None


### PR DESCRIPTION
## Summary
- register teardown handler to clear current user after each request
- document automatic context cleanup
- add test verifying user context is reset

## Testing
- `poetry run isort flarchitect/authentication/user.py flarchitect/core/architect.py docs/source/authentication.rst tests/test_user_context.py`
- `poetry run black flarchitect/authentication/user.py flarchitect/core/architect.py tests/test_user_context.py`
- `poetry run ruff check flarchitect/authentication/user.py flarchitect/core/architect.py tests/test_user_context.py`
- `pytest tests/test_user_context.py tests/test_authentication.py tests/test_roles_required.py tests/test_demo_authentication.py`

## Labels
- fix

------
https://chatgpt.com/codex/tasks/task_e_689dde9cdd748322afe4950abeafff82