### PR TITLE
feat(specs): support regex-based path converter transformation

### DIFF
--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -1,6 +1,7 @@
 import copy
 import os
 import random
+import re
 from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime, timedelta
@@ -815,9 +816,11 @@ def convert_path_to_openapi(path: str) -> str:
         path (str): Flask path to convert.
 
     Returns:
-        str: OpenAPI path.
+        str: OpenAPI path with Flask converters removed.
     """
-    return path.replace("<", "{").replace(">", "}").replace("<int:", "")
+    pattern = re.compile(r"<(?:[^:<>]+:)?([^<>]+)>")
+    # Replace Flask path converters with OpenAPI-style parameters
+    return pattern.sub(r"{\1}", path)
 
 
 def initialize_spec_template(

--- a/tests/test_specs_utils.py
+++ b/tests/test_specs_utils.py
@@ -1,6 +1,19 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
 from flask import Flask
 
-from flarchitect.specs.utils import scrape_extra_info_from_spec_data
+spec_utils_path = (
+    Path(__file__).resolve().parents[1] / "flarchitect" / "specs" / "utils.py"
+)
+spec_utils_spec = importlib.util.spec_from_file_location("spec_utils", spec_utils_path)
+spec_utils_module = importlib.util.module_from_spec(spec_utils_spec)
+assert spec_utils_spec.loader is not None  # for mypy
+spec_utils_spec.loader.exec_module(spec_utils_module)
+
+convert_path_to_openapi = spec_utils_module.convert_path_to_openapi
+scrape_extra_info_from_spec_data = spec_utils_module.scrape_extra_info_from_spec_data
 
 
 def test_scrape_extra_info_logs_missing_fields(monkeypatch):
@@ -15,3 +28,17 @@ def test_scrape_extra_info_logs_missing_fields(monkeypatch):
     with app.app_context():
         scrape_extra_info_from_spec_data({"function": lambda: None}, method="GET")
     assert any("model" in msg and "schema" in msg for msg in messages)
+
+
+@pytest.mark.parametrize(
+    ("flask_path", "openapi_path"),
+    [
+        ("/users/<int:id>", "/users/{id}"),
+        ("/files/<path:filepath>", "/files/{filepath}"),
+        ("/items/<uuid:item_id>", "/items/{item_id}"),
+        ("/simple/<name>", "/simple/{name}"),
+    ],
+)
+def test_convert_path_to_openapi(flask_path: str, openapi_path: str) -> None:
+    """convert_path_to_openapi should replace Flask converters with OpenAPI params."""
+    assert convert_path_to_openapi(flask_path) == openapi_path


### PR DESCRIPTION
## Summary
- transform Flask path converters using regex
- add tests for multiple converter types

## Testing
- `pytest tests/test_specs_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689ddeab6b2483229bd68ede6f37e86c