### PR TITLE
feat(add-bearer-authentication-support): feat(specs): support bearer auth security scheme

### DIFF
--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -35,6 +35,14 @@ Accessing the spec
 The generated schema is automatically served at ``/openapi.json``. Override
 the URL with ``API_SPEC_ROUTE`` if you need to mount the document elsewhere.
 
+Security scheme
+---------------
+
+flarchitect defines a ``bearerAuth`` security scheme using HTTP bearer tokens
+with JWTs. Routes that require authentication reference this scheme via a
+``security`` declaration instead of documenting an explicit ``Authorization``
+header parameter.
+
 Exporting to a file
 -------------------
 

--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -112,6 +112,15 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
                 **self._get_license_info(),
                 **self._get_logo_info(),
             },
+            "components": {
+                "securitySchemes": {
+                    "bearerAuth": {
+                        "type": "http",
+                        "scheme": "bearer",
+                        "bearerFormat": "JWT",
+                    }
+                }
+            },
             **self._get_servers_info(),
         }
         return {**api_spec_data, **kwargs}

--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -1077,15 +1077,9 @@ def handle_authorization(f: Callable, spec_template: dict[str, Any]):
                     if decorator.__name__ == "roles_required"
                     else "Roles accepted"
                 )
-                spec_template["parameters"].append(
-                    {
-                        "name": "Authorization",
-                        "in": "header",
-                        "description": "JWT token required",
-                        "required": True,
-                        "schema": {"type": "string", "format": "jwt"},
-                    }
-                )
+                security = spec_template.setdefault("security", [])
+                if not any("bearerAuth" in scheme for scheme in security):
+                    security.append({"bearerAuth": []})
                 break
 
     if required_roles and roles_label:

--- a/tests/test_roles_required.py
+++ b/tests/test_roles_required.py
@@ -92,9 +92,7 @@ def test_openapi_documents_roles() -> None:
 
     handle_authorization(view, spec_template)
 
-    assert any(
-        param["name"] == "Authorization" for param in spec_template["parameters"]
-    )
+    assert spec_template["security"] == [{"bearerAuth": []}]
     assert (
         "Roles required: admin, editor"
         in spec_template["responses"]["401"]["description"]
@@ -127,9 +125,7 @@ def test_openapi_documents_roles_accepted() -> None:
 
     handle_authorization(view, spec_template)
 
-    assert any(
-        param["name"] == "Authorization" for param in spec_template["parameters"]
-    )
+    assert spec_template["security"] == [{"bearerAuth": []}]
     assert (
         "Roles accepted: admin, editor"
         in spec_template["responses"]["401"]["description"]

--- a/tests/test_spec_route.py
+++ b/tests/test_spec_route.py
@@ -10,6 +10,11 @@ def test_default_spec_route():
     data = resp.get_json()
     assert isinstance(data, dict)
     assert data.get("openapi")
+    assert data["components"]["securitySchemes"]["bearerAuth"] == {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+    }
 
 
 def test_custom_spec_route():


### PR DESCRIPTION
## Summary
- add global `bearerAuth` security scheme to OpenAPI spec generation
- reference JWT bearer auth via route-level security instead of manual headers
- document and test new security scheme

## Testing
- `ruff check flarchitect/specs/utils.py flarchitect/specs/generator.py tests/test_roles_required.py tests/test_spec_route.py`
- `isort flarchitect/specs/utils.py flarchitect/specs/generator.py tests/test_roles_required.py tests/test_spec_route.py`
- `black flarchitect/specs/utils.py flarchitect/specs/generator.py tests/test_roles_required.py tests/test_spec_route.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ddeaf5e108322959edee1689e043b