### PR TITLE
feat(add-decimal-type-to-type_mapping): feat(specs): add Decimal field type mapping

### DIFF
--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -1125,6 +1125,10 @@ def get_openapi_meta_data(field_obj: fields.Field) -> dict[str, Any]:
             else field_type.__name__.lower()
         )
 
+    if field_type == fields.Decimal and (fmt := field_obj.metadata.get("format")):
+        # Add optional format for Decimal fields if provided in metadata
+        openapi_type_info["format"] = fmt
+
     if field_type == fields.Function:
         openapi_type_info["format"] = "uri"
         openapi_type_info["example"] = "/url/to/resource"
@@ -1214,6 +1218,7 @@ type_mapping = {
     fields.String: "string",
     fields.Integer: "integer",
     fields.Float: "number",
+    fields.Decimal: "number",
     fields.Boolean: "boolean",
     fields.DateTime: "string",
     fields.Date: "string",

--- a/tests/test_decimal_field_metadata.py
+++ b/tests/test_decimal_field_metadata.py
@@ -1,0 +1,26 @@
+from marshmallow import Schema, fields
+
+from flarchitect.specs.utils import get_openapi_meta_data
+
+
+class DecimalSchema(Schema):
+    """Schema with Decimal fields for metadata extraction tests."""
+
+    value = fields.Decimal()
+    value_with_format = fields.Decimal(metadata={"format": "decimal"})
+
+
+def test_decimal_field_without_format():
+    """Decimal field without explicit format returns only type information."""
+    schema = DecimalSchema()
+    meta = get_openapi_meta_data(schema.fields["value"])
+    assert meta["type"] == "number"
+    assert "format" not in meta
+
+
+def test_decimal_field_with_format():
+    """Decimal field with format metadata includes the format key."""
+    schema = DecimalSchema()
+    meta = get_openapi_meta_data(schema.fields["value_with_format"])
+    assert meta["type"] == "number"
+    assert meta["format"] == "decimal"


### PR DESCRIPTION
## Summary
- map `fields.Decimal` to OpenAPI `number` type and support optional format metadata
- test metadata generation for Decimal fields with and without format

## Testing
- `ruff check --fix flarchitect/specs/utils.py tests/test_decimal_field_metadata.py`
- `pytest tests/test_decimal_field_metadata.py tests/test_version.py::test_version_matches_package -q`


------
https://chatgpt.com/codex/tasks/task_e_689ddeb178d88322a47daf72e0725ecc