### PR TITLE
feat(handle-user-authentication-exceptions): fix(authentication): distinguish unauthenticated from insufficient role

### DIFF
--- a/tests/test_roles_required.py
+++ b/tests/test_roles_required.py
@@ -26,9 +26,17 @@ def test_roles_required_direct() -> None:
     set_current_user(SimpleNamespace(roles=["admin"]))
     assert sample() == "ok"
 
-    set_current_user(SimpleNamespace(roles=["user"]))
-    with pytest.raises(CustomHTTPException):
+    set_current_user(None)
+    with pytest.raises(CustomHTTPException) as exc:
         sample()
+    assert exc.value.status_code == 401
+    assert exc.value.reason == "Authentication required"
+
+    set_current_user(SimpleNamespace(roles=["user"]))
+    with pytest.raises(CustomHTTPException) as exc:
+        sample()
+    assert exc.value.status_code == 403
+    assert exc.value.reason == "Insufficient role"
 
 
 @pytest.fixture()
@@ -76,6 +84,10 @@ def test_schema_constructor_applies_roles(
     resp = client.get("/protected")
     assert resp.status_code == 200
 
+    holder.user = None
+    resp = client.get("/protected")
+    assert resp.status_code == 401
+
     holder.user = SimpleNamespace(roles=["user"])
     resp = client.get("/protected")
     assert resp.status_code == 403
@@ -111,9 +123,17 @@ def test_roles_accepted_direct() -> None:
     set_current_user(SimpleNamespace(roles=["editor"]))
     assert sample() == "ok"
 
-    set_current_user(SimpleNamespace(roles=["user"]))
-    with pytest.raises(CustomHTTPException):
+    set_current_user(None)
+    with pytest.raises(CustomHTTPException) as exc:
         sample()
+    assert exc.value.status_code == 401
+    assert exc.value.reason == "Authentication required"
+
+    set_current_user(SimpleNamespace(roles=["user"]))
+    with pytest.raises(CustomHTTPException) as exc:
+        sample()
+    assert exc.value.status_code == 403
+    assert exc.value.reason == "Insufficient role"
 
 
 def test_openapi_documents_roles_accepted() -> None:


### PR DESCRIPTION
## Summary
- raise `CustomHTTPException` with 401 when no user is present in role checks
- keep 403 for authenticated users missing required roles
- expand tests for `roles_required`/`roles_accepted` to cover unauthenticated cases

## Testing
- `ruff check tests/test_roles_required.py flarchitect/authentication/roles.py`
- `python -m black tests/test_roles_required.py flarchitect/authentication/roles.py`
- `python -m isort tests/test_roles_required.py flarchitect/authentication/roles.py`
- `pytest tests/test_roles_required.py`


------
https://chatgpt.com/codex/tasks/task_e_689dde974fd08322acd6c5fa52ab03ac