### PR TITLE
feat(create-demo/cors-subdirectory-with-api-cors-support): feat(demo): add CORS demo

### DIFF
--- a/demo/cors/README.md
+++ b/demo/cors/README.md
@@ -1,0 +1,20 @@
+# CORS Demo
+
+This example enables Cross-Origin Resource Sharing using `API_ENABLE_CORS`.
+Requests to `/ping` return an `Access-Control-Allow-Origin` header, allowing
+clients from any origin to call the API.
+
+## Run
+
+```bash
+python demo/cors/app.py
+```
+
+Verify the header:
+
+```bash
+curl -i -H "Origin: http://example.com" http://127.0.0.1:5000/ping
+```
+
+The response includes `Access-Control-Allow-Origin: *` confirming CORS is
+active.

--- a/demo/cors/app.py
+++ b/demo/cors/app.py
@@ -1,0 +1,50 @@
+"""Demo application showcasing Cross-Origin Resource Sharing (CORS).
+
+The application exposes a single ``/ping`` route. When ``API_ENABLE_CORS`` is
+set to ``True`` the response includes the ``Access-Control-Allow-Origin``
+header, allowing browsers to call the API from other origins.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from flask import Flask
+
+from flarchitect import Architect
+
+
+def create_app(config: dict[str, Any] | None = None) -> Flask:
+    """Application factory enabling CORS support.
+
+    Args:
+        config: Optional mapping to override default configuration.
+
+    Returns:
+        Configured :class:`~flask.Flask` instance.
+    """
+
+    app = Flask(__name__)
+    app.config.update(
+        API_ENABLE_CORS=True,
+        CORS_RESOURCES={r"/ping": {"origins": "*"}},
+        FULL_AUTO=False,
+        API_CREATE_DOCS=False,
+    )
+    if config:
+        app.config.update(config)
+
+    with app.app_context():
+        Architect(app)
+
+    @app.get("/ping")
+    def ping() -> str:
+        """Return a simple pong message."""
+
+        return "pong"
+
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution only
+    create_app().run(debug=True)


### PR DESCRIPTION
## Summary
- add CORS demo with configurable `/ping` endpoint
- document running the demo and verifying CORS headers

## Testing
- `python -m isort demo/cors/app.py`
- `python -m black demo/cors/app.py`
- `python -m ruff check demo/cors/app.py --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689dde7d696c83228837148e479ad8b9