### PR TITLE
feat(update-simple_cache-with-clear-method): feat(core): add cache clearing and expiration purge

### DIFF
--- a/tests/core/test_simple_cache.py
+++ b/tests/core/test_simple_cache.py
@@ -1,0 +1,26 @@
+import time
+from importlib.machinery import SourceFileLoader
+
+SimpleCache = (
+    SourceFileLoader("simple_cache", "flarchitect/core/simple_cache.py")
+    .load_module()
+    .SimpleCache
+)
+
+
+def test_clear_removes_entries():
+    cache = SimpleCache()
+    cache.set("a", 1)
+    assert cache.get("a") == 1
+    cache.clear()
+    assert cache.get("a") is None
+    assert cache._cache == {}
+
+
+def test_get_purges_expired_entries():
+    cache = SimpleCache()
+    cache.set("a", 1, timeout=1)
+    cache.set("b", 2, timeout=5)
+    time.sleep(1.1)
+    assert cache.get("b") == 2
+    assert "a" not in cache._cache


### PR DESCRIPTION
## Summary
- allow SimpleCache to clear stored entries and remove expired values on access
- test cache clearing and automatic purge of expired entries

## Testing
- `pytest tests/core/test_simple_cache.py`
- `pytest tests/test_cache.py` *(fails: ModuleNotFoundError: No module named 'dicttoxml')*

------
https://chatgpt.com/codex/tasks/task_e_689de7a42f0c8322bbfb649090da4f32