### PR TITLE
feat(add-type-hints-and-update-docstring-in-init_app): docs(core): expand init_app usage

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -7,6 +7,28 @@ several options for these scenarios. The following sections walk through
 common patterns such as rate limiting, cache configuration and response
 metadata.
 
+Initialising with optional features
+-----------------------------------
+
+``Architect.init_app`` accepts keyword arguments that toggle optional
+behaviour like caching, CORS handling and automatic documentation
+generation.
+
+.. code:: python
+
+    from flarchitect import Architect
+
+    architect = Architect()
+    architect.init_app(
+        app,
+        cache={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 300},
+        enable_cors=True,
+        create_docs=True,
+    )
+
+These keywords mirror their respective ``API_*`` configuration values and
+allow feature flags to be set programmatically during initialisation.
+
 As traffic increases, managing how often clients can hit your API becomes
 critical.
 

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -151,14 +151,49 @@ class Architect(AttributeInitializerMixin):
         server_fd = os.environ.get("WERKZEUG_SERVER_FD")
         return server_fd is not None and run_main != "true"
 
-    def init_app(self, app: Flask, *args, **kwargs):
-        """
-        Initializes the Architect object.
+    def init_app(self, app: Flask, *args: Any, **kwargs: Any) -> None:
+        """Initialise the extension for a given :class:`flask.Flask` app.
+
+        The method wires core services into ``app``, enabling optional
+        behaviours such as response caching, Cross-Origin Resource Sharing
+        (CORS) headers and automatic OpenAPI documentation. Any additional
+        ``kwargs`` are forwarded to :meth:`init_api` and
+        :meth:`init_apispec`.
 
         Args:
-            app (Flask): The flask app.
-            *args (list): List of arguments.
-            **kwargs (dict): Dictionary of keyword arguments.
+            app: The Flask application to register with.
+            *args: Positional arguments forwarded to
+                :class:`~flarchitect.utils.general.AttributeInitializerMixin`.
+            **kwargs: Optional keyword arguments affecting initialisation.
+                Supported keys include:
+
+                ``cache`` (dict | bool, optional): Configuration for caching
+                responses. When truthy, ``API_CACHE_TYPE`` and
+                ``API_CACHE_TIMEOUT`` are used to set up caching.
+
+                ``enable_cors`` (bool, optional): Enable CORS handling when
+                ``True``. The ``CORS_RESOURCES`` mapping defines allowed
+                origins.
+
+                ``create_docs`` (bool, optional): Generate ReDoc and OpenAPI
+                documentation when ``True``.
+
+        Examples:
+            Basic initialisation::
+
+                architect = Architect()
+                architect.init_app(app)
+
+            With optional features::
+
+                architect = Architect()
+                architect.init_app(
+                    app,
+                    cache={"CACHE_TYPE": "SimpleCache", "CACHE_DEFAULT_TIMEOUT": 300},
+                    enable_cors=True,
+                    create_docs=True,
+                )
+
         """
         super().__init__(app, *args, **kwargs)
         self._register_app(app)


### PR DESCRIPTION
## Summary
- add detailed keyword argument documentation and examples for `init_app`
- mention optional initialisation features in advanced configuration docs

## Testing
- `ruff check flarchitect/core/architect.py`
- `pytest` *(fails: Interrupted: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689de7a6a48c83229eeb1b000b690f74