### PR TITLE
feat(add-example-code-block-for-api-description): docs(openapi): document API_DESCRIPTION config

### DIFF
--- a/docs/source/openapi.rst
+++ b/docs/source/openapi.rst
@@ -70,5 +70,13 @@ A number of configuration keys let you tailor the output:
 * ``API_LOGO_BACKGROUND`` – CSS colour value behind the logo (e.g.
   ``"#fff"`` or ``"transparent"``).
 
+For example, to load a Markdown file into the specification's info section:
+
+.. code-block:: python
+
+    app.config["API_DESCRIPTION"] = "docs/README.md"
+
+The contents of ``docs/README.md`` are rendered in the spec's ``info`` section.
+
 See :doc:`configuration` for the full list of options.
 


### PR DESCRIPTION
## Summary
- document how to load a Markdown file via API_DESCRIPTION for rendering in OpenAPI spec info section

## Testing
- `ruff check .` *(fails: F821 Undefined name `algorithm` in flarchitect/authentication/jwt.py)*
- `isort . --check-only` *(fails: imports are incorrectly sorted and/or formatted)*
- `black . --check` *(fails: files would be reformatted)*
- `pytest` *(fails: 49 errors during collection)*

Labels: docs

------
https://chatgpt.com/codex/tasks/task_e_689de7be42248322b62aa04a02aa03e1