### PR TITLE
feat(update-quickstart.rst-with-create_response-example): docs(quickstart): replace raw list example with create_response payload

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -87,11 +87,23 @@ Example response:
 
 .. code:: json
 
-    [
-      {"id": 1, "name": "Test Author"}
-    ]
+    {
+      "datetime": "2024-01-01T00:00:00.0000+00:00",
+      "api_version": "0.1.0",
+      "status_code": 200,
+      "response_ms": 15,
+      "total_count": 1,
+      "next_url": null,
+      "previous_url": null,
+      "errors": null,
+      "value": [
+        {"id": 1, "name": "Test Author"}
+      ]
+    }
 
-A JSON array confirms the API is up and responding as expected.
+This structured payload is produced by :func:`create_response` and shows the
+standard metadata flarchitect includes by default. To return a bare list,
+disable the metadata fields via the ``API_DUMP_*`` configuration options.
 
 From Model to API
 ----------------------------------------


### PR DESCRIPTION
## Summary
- replace raw list response example with full create_response payload
- document how to return a bare list by disabling metadata

## Testing
- `ruff check flarchitect tests --exclude flarchitect/authentication/jwt.py`
- `black --check .`
- `isort --check-only .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689de7b20f3083229031ef2d06ea1fe5