### PR TITLE
feat(add-token-store-documentation-and-code-snippet): docs(auth): document refresh token storage

### DIFF
--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -135,6 +135,41 @@ This decorator reads the ``Authorization`` header, validates the token and sets
 ``current_user``. Automatically created endpoints do not need it because global
 settings already apply authentication.
 
+Refresh token storage
+~~~~~~~~~~~~~~~~~~~~~
+
+By default, flarchitect persists JWT refresh tokens in an SQL table named
+``refresh_tokens``. The table contains four columns:
+
+* ``token`` – the encoded refresh token (primary key)
+* ``user_pk`` – the user's primary key as a string
+* ``user_lookup`` – the configured user lookup value
+* ``expires_at`` – the token's expiry timestamp
+
+The table is created automatically when a refresh token is stored. You can
+manage tokens directly using helpers from
+``flarchitect.authentication.token_store``:
+
+.. code-block:: python
+
+   from datetime import datetime, timedelta, timezone
+   from flarchitect.authentication.token_store import (
+       delete_refresh_token,
+       get_refresh_token,
+       store_refresh_token,
+   )
+
+   expires = datetime.now(timezone.utc) + timedelta(days=1)
+   store_refresh_token(
+       "encoded-token", user_pk="1", user_lookup="alice", expires_at=expires
+   )
+
+   stored = get_refresh_token("encoded-token")
+   if stored:
+       print(stored.user_pk, stored.expires_at)
+
+   delete_refresh_token("encoded-token")
+
 Basic authentication
 --------------------
 


### PR DESCRIPTION
## Summary
- document default SQL table for `flarchitect.authentication.token_store`
- demonstrate storing, querying, and deleting refresh tokens

## Testing
- `ruff check --no-fix docs/source/authentication.rst` (fails: SyntaxError: Got unexpected token `)
- `black docs/source/authentication.rst` (fails: Cannot parse)
- `isort docs/source/authentication.rst --check-only`
- `pytest` (fails: 49 errors during collection)


------
https://chatgpt.com/codex/tasks/task_e_689de7c0aed48322999a0bd2a77db4c1