### PR TITLE
feat(add-caching-backend-examples-in-docs): docs(cache): document RedisCache fallback example

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -100,6 +100,32 @@ is installed, set ``API_CACHE_TYPE`` to any supported backend such as
 activates a small in-memory cache bundled with ``flarchitect``; any other
 value will raise a :class:`RuntimeError`. Use ``API_CACHE_TIMEOUT`` to control
 how long items remain cached.
+
+Example ``RedisCache`` setup with a ``SimpleCache`` fallback and a cached
+``GET`` request::
+
+    from flask import Flask
+    from flarchitect import Architect
+    import time
+
+    app = Flask(__name__)
+    try:
+        import flask_caching  # requires installing ``flask-caching``
+        app.config["API_CACHE_TYPE"] = "RedisCache"
+        app.config["CACHE_REDIS_URL"] = "redis://localhost:6379/0"
+    except ModuleNotFoundError:
+        app.config["API_CACHE_TYPE"] = "SimpleCache"
+
+    arch = Architect(app)
+
+    @app.get("/time")
+    def get_time():
+        return {"now": time.time()}
+
+    with app.test_client() as client:
+        client.get("/time")  # first call stored in cache
+        client.get("/time")  # second call served from cache
+
 For a runnable example demonstrating cached responses see the `caching demo <https://github.com/lewis-morris/flarchitect/tree/master/demo/caching>`_.
 
 After securing throughput, you can also shape what your clients see in each


### PR DESCRIPTION
## Summary
- illustrate RedisCache configuration with SimpleCache fallback and cached GET request example

## Testing
- `ruff check .` *(fails: F821 Undefined name `algorithm`)*
- `black --check docs/source/advanced_configuration.rst` *(fails: Cannot parse RST file as Python)*
- `isort --check-only docs/source/advanced_configuration.rst` *(fails: file incorrectly sorted)*
- `pytest` *(fails: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689de7ccb67c832285c41a74922732db