### PR TITLE
feat(modify-documentation-for-flarchitect): docs(index): highlight rapid, customizable API generation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,9 +68,10 @@ flarchitect
 --------------------------------------------
 
 
+**Build APIs fast, customise at will.**
 
 **flarchitect** turns your `SQLAlchemy`_ models into a polished RESTful API complete with interactive `Redoc`_ or Swagger UI documentation.
-Hook it into your `Flask`_ application and you'll have endpoints, schemas and docs in moments.
+Hook it into your `Flask`_ application and you'll have endpoints, schemas and docs in moments. It reduces boilerplate while letting you tailor behaviour to your needs.
 
 What can it do?
 


### PR DESCRIPTION
## Summary
- add tagline underscoring rapid API generation and customization
- mention reduced boilerplate with flexible behaviour

## Testing
- `isort --check-only docs/source/index.rst`
- `black --check .` *(fails: would reformat 62 files)*
- `ruff check docs/source/index.rst` *(fails: SyntaxError in RST file)*
- `pytest` *(fails: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689de826b1288322974e26ee3403b3d7