### PR TITLE
docs(advanced-configuration): add nested writes example

### DIFF
--- a/docs/source/advanced_configuration.rst
+++ b/docs/source/advanced_configuration.rst
@@ -187,6 +187,36 @@ Nested writes are disabled by default. Enable them globally with
 ``API_ALLOW_NESTED_WRITES = True`` or per model via
 ``Meta.allow_nested_writes``.
 
+.. code:: python
+
+    class Config:
+        API_ALLOW_NESTED_WRITES = True
+
+    class Parent(db.Model):
+        id = db.Column(db.Integer, primary_key=True)
+        name = db.Column(db.String)
+        children = db.relationship("Child", back_populates="parent")
+
+        class Meta:
+            allow_nested_writes = True
+
+    class Child(db.Model):
+        id = db.Column(db.Integer, primary_key=True)
+        name = db.Column(db.String)
+        parent_id = db.Column(db.Integer, db.ForeignKey("parent.id"))
+        parent = db.relationship("Parent", back_populates="children")
+
+        class Meta:
+            allow_nested_writes = True
+
+With this configuration a nested object can be created in the same request::
+
+    POST /api/parent
+    {
+        "name": "Jane",
+        "children": [{"name": "Junior"}]
+    }
+
 Depth limits
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary
- document enabling nested model creation with global and model-level configuration
- add POST example creating a parent and nested child

## Testing
- `ruff check flarchitect` *(fails: F821 Undefined name `algorithm`)*
- `black --check docs/source/advanced_configuration.rst` *(fails: Cannot parse for target version Python 3.13: 1:9)*
- `isort --check-only docs/source/advanced_configuration.rst` *(fails: Imports are incorrectly sorted and/or formatted)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689de7c708cc8322ac6c15baa96bd1f5