### PR TITLE
feat(edit-readme.md-for-clarity-and-emphasis): docs(readme): highlight quick API with control

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 
 
-flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQLAlchemy models into a production-ready REST API with almost no boilerplate. It automatically builds CRUD endpoints, generates interactive Redoc documentation and keeps responses consistent so you can focus on your application logic.
+flarchitect is a friendly Flask extension that turns your SQLAlchemy or Flask-SQLAlchemy models into a production-ready REST API in minutes while keeping you in full control of your models and endpoints. It automatically builds CRUD endpoints, generates interactive Redoc documentation and keeps responses consistent so you can focus on your application logic.
 
 ## Why flarchitect?
 
-If you're new here, welcome! flarchitect gets you from data models to a fully fledged REST API in minutes, letting you focus on the features that matter rather than plumbing.
+If you're new here, welcome! flarchitect gets you from data models to a fully fledged REST API in minutes, saving you time without sacrificing quality or customization.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- Emphasize production-ready API in minutes while keeping full control over models and endpoints
- Reinforce time saved without sacrificing quality or customization in the "Why flarchitect?" section

## Testing
- `ruff check .` *(fails: flarchitect/authentication/jwt.py:161:75 F821 Undefined name `algorithm`)*
- `black --check .` *(fails: would reformat many files)*
- `isort --check-only .` *(fails: imports incorrectly sorted in multiple files)*
- `pytest` *(fails: 49 errors during collection)*

Labels: docs

------
https://chatgpt.com/codex/tasks/task_e_689de823674483229da7b1477e62cda1