### PR TITLE
refactor(jwt-token-handling): feat(authentication): persist refresh tokens via token store

### DIFF
--- a/flarchitect/authentication/token_store.py
+++ b/flarchitect/authentication/token_store.py
@@ -82,6 +82,7 @@ def get_refresh_token(token: str) -> RefreshToken | None:
     """
     session = get_session(RefreshToken)
     _ensure_table(session)
+    session.expire_all()
     return session.get(RefreshToken, token)
 
 
@@ -98,3 +99,4 @@ def delete_refresh_token(token: str) -> None:
         if instance is not None:
             session.delete(instance)
             session.commit()
+            session.expire_all()

--- a/tests/authentication/test_token_persistence.py
+++ b/tests/authentication/test_token_persistence.py
@@ -1,0 +1,52 @@
+"""Tests for refresh token persistence logic."""
+
+from __future__ import annotations
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from flarchitect.authentication.jwt import generate_refresh_token, refresh_access_token
+from flarchitect.authentication.token_store import get_refresh_token
+from flarchitect.exceptions import CustomHTTPException
+from tests.test_authentication import User
+from tests.test_authentication import client_jwt as client_jwt_fixture
+
+client_jwt = client_jwt_fixture
+
+
+def test_refresh_token_stored(client_jwt: tuple[FlaskClient, str, str]) -> None:
+    """Generated refresh tokens are persisted."""
+    client, _, refresh_token = client_jwt
+    app: Flask = client.application
+    with app.app_context():
+        stored = get_refresh_token(refresh_token)
+        assert stored is not None
+        assert stored.user_lookup == "carol"
+
+
+def test_refresh_access_token_deletes_token(
+    client_jwt: tuple[FlaskClient, str, str],
+) -> None:
+    """Using a refresh token removes it from the store."""
+    client, _, refresh_token = client_jwt
+    app: Flask = client.application
+    with app.app_context():
+        assert get_refresh_token(refresh_token) is not None
+        refresh_access_token(refresh_token)
+        assert get_refresh_token(refresh_token) is None
+
+
+def test_expired_refresh_token_deleted(
+    client_jwt: tuple[FlaskClient, str, str],
+) -> None:
+    """Expired refresh tokens are purged when used."""
+    client, _, _ = client_jwt
+    app: Flask = client.application
+    with app.app_context():
+        user = User.query.filter_by(username="carol").one()
+        expired_refresh = generate_refresh_token(user, expires_in_minutes=-1)
+        assert get_refresh_token(expired_refresh) is not None
+        with pytest.raises(CustomHTTPException):
+            refresh_access_token(expired_refresh)
+        assert get_refresh_token(expired_refresh) is None

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -10,6 +10,7 @@ from flask import Flask, Response, request
 from flask.testing import FlaskClient
 from flask_sqlalchemy import SQLAlchemy
 from marshmallow import Schema, fields
+from sqlalchemy.pool import StaticPool
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from flarchitect import Architect
@@ -19,7 +20,7 @@ from flarchitect.authentication.jwt import (
     generate_refresh_token,
     refresh_access_token,
 )
-from flarchitect.authentication.token_store import RefreshToken
+from flarchitect.authentication.token_store import RefreshToken, get_refresh_token
 from flarchitect.authentication.user import (
     current_user,
     get_current_user,
@@ -29,7 +30,6 @@ from flarchitect.exceptions import CustomHTTPException
 from flarchitect.specs.generator import register_routes_with_spec
 from flarchitect.utils.general import generate_readme_html
 from flarchitect.utils.response_helpers import create_response
-from flarchitect.utils.session import get_session
 
 db = SQLAlchemy()
 
@@ -148,6 +148,7 @@ def client_jwt() -> Generator[tuple[FlaskClient, str, str], None, None]:
     app = Flask(__name__)
     app.config.update(
         SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_ENGINE_OPTIONS={"poolclass": StaticPool},
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         FULL_AUTO=False,
         API_CREATE_DOCS=False,
@@ -176,6 +177,7 @@ def client_jwt() -> Generator[tuple[FlaskClient, str, str], None, None]:
             return {"username": current_user.username}
 
         db.create_all()
+        RefreshToken.metadata.create_all(bind=db.engine)
         user = User(
             username="carol",
             password_hash=generate_password_hash("pass"),
@@ -193,6 +195,7 @@ def _create_app_with_docs() -> Flask:
     app = Flask(__name__)
     app.config.update(
         SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_ENGINE_OPTIONS={"poolclass": StaticPool},
         SQLALCHEMY_TRACK_MODIFICATIONS=False,
         FULL_AUTO=False,
         API_CREATE_DOCS=True,
@@ -368,8 +371,10 @@ def test_jwt_success_and_failure(client_jwt: tuple[FlaskClient, str, str]) -> No
     assert resp.get_json()["value"]["username"] == "carol"
     assert get_current_user() is None
 
-    new_access_token, user = refresh_access_token(refresh_token)
-    assert user.username == "carol"
+    with client.application.app_context():
+        new_access_token, user = refresh_access_token(refresh_token)
+        assert user.username == "carol"
+        assert get_refresh_token(refresh_token) is None
     resp_new = client.get(
         "/jwt", headers={"Authorization": f"Bearer {new_access_token}"}
     )
@@ -381,7 +386,7 @@ def test_jwt_success_and_failure(client_jwt: tuple[FlaskClient, str, str]) -> No
     assert resp_bad.status_code == 401
     assert get_current_user() is None
 
-    with pytest.raises(CustomHTTPException):
+    with client.application.app_context(), pytest.raises(CustomHTTPException):
         refresh_access_token(refresh_token)
     assert get_current_user() is None
 
@@ -403,7 +408,6 @@ def test_refresh_access_token_missing_key(
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.reason == "REFRESH_SECRET_KEY missing"
-
 
 
 def test_jwt_expiry_config(client_jwt: tuple[FlaskClient, str, str]) -> None:


### PR DESCRIPTION
## Summary
- persist refresh tokens using database-backed token store instead of in-memory dict
- validate refresh tokens via token store, deleting expired entries
- test refresh token persistence and access token refresh

## Testing
- `ruff check flarchitect/authentication/jwt.py flarchitect/authentication/token_store.py tests/authentication/test_token_persistence.py tests/test_authentication.py`
- `black flarchitect/authentication/jwt.py flarchitect/authentication/token_store.py tests/authentication/test_token_persistence.py tests/test_authentication.py`
- `pytest tests/authentication/test_token_persistence.py tests/test_authentication.py::test_jwt_success_and_failure tests/test_authentication.py::test_refresh_access_token_missing_key tests/test_authentication.py::test_jwt_expiry_config tests/test_authentication.py::test_jwt_algorithm_config -q`

------
https://chatgpt.com/codex/tasks/task_e_689de7a24b5c832298cb8c05a3bb4553