### PR TITLE
feat(hide-patch-models-from-documentation): fix(specs): hide patch and auto schemas in swagger

### DIFF
--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -19,7 +19,6 @@ from flarchitect.core.routes import (
 )
 from flarchitect.logging import logger
 from flarchitect.specs.utils import (
-    _prepare_patch_schema,
     append_parameters,
     convert_path_to_openapi,
     handle_authorization,
@@ -484,8 +483,6 @@ def register_schemas(
         None
     """
 
-    put_input_schema = _prepare_patch_schema(input_schema)
-
     # ``MarshmallowPlugin`` keeps track of registered schemas. Inspect the
     # plugin to avoid adding the same schema class twice, which would trigger
     # warnings from ``apispec``.
@@ -494,7 +491,7 @@ def register_schemas(
         getattr(getattr(plugin, "converter", None), "refs", {}) if plugin else {}
     )
 
-    for schema in [input_schema, output_schema, put_input_schema]:
+    for schema in [input_schema, output_schema]:
         if schema:
             model = schema.get_model() if hasattr(schema, "get_model") else None
 
@@ -603,7 +600,3 @@ def register_routes_with_spec(
                         path=convert_path_to_openapi(path),
                         operations={http_method.lower(): endpoint_spec},
                     )
-
-    from flarchitect.schemas.bases import AutoSchema
-
-    register_schemas(architect.api_spec, AutoSchema)

--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -254,11 +254,9 @@ def _add_request_body_to_spec_template(
         None
     """
     case = get_config_or_model_meta("API_SCHEMA_CASE", model=model, default="camel")
-    name = convert_case(
-        ("patch_" if http_method == "PATCH" else "")
-        + input_schema.__name__.replace("Schema", ""),
-        case,
-    )
+    base_name = input_schema.__name__.replace("Schema", "")
+    name = convert_case(base_name, case)
+    # Use the base schema name for PATCH operations to avoid extra spec entries
 
     spec_template["requestBody"] = {
         "description": f"`{name}` payload.",

--- a/tests/test_flask_config.py
+++ b/tests/test_flask_config.py
@@ -36,6 +36,14 @@ def test_basic_change_title_and_version(client):
     assert "0.2.0" in html
 
 
+def test_hidden_patch_and_auto_schemas(client) -> None:
+    """Ensure patch and auto schemas are excluded from OpenAPI docs."""
+    swagger = client.get("/swagger.json").json
+    schema_names = swagger["components"]["schemas"].keys()
+    assert "auto" not in schema_names
+    assert all(not name.startswith("patch") for name in schema_names)
+
+
 @pytest.fixture
 def app_meth():
     app_new = create_app(

--- a/tests/test_spec_registration.py
+++ b/tests/test_spec_registration.py
@@ -29,7 +29,9 @@ def test_register_schemas_avoids_duplicates():
         register_schemas(spec, schema)
         register_schemas(spec, schema)
 
-    assert not any("has already been added to the spec" in str(w.message) for w in caught)
+    assert not any(
+        "has already been added to the spec" in str(w.message) for w in caught
+    )
 
 
 class ItemSchema(Schema):
@@ -52,4 +54,4 @@ def test_register_schemas_preserves_name_and_case():
 
     assert schema.__class__.__name__ == "ItemSchema"
     assert "item" in spec.components.schemas
-    assert "patchItem" in spec.components.schemas
+    assert "patchItem" not in spec.components.schemas


### PR DESCRIPTION
## Summary
- avoid registering patch schemas and AutoSchema in OpenAPI docs
- update request body generation to reuse base schema names
- test to ensure patch and auto schemas are hidden

## Testing
- `pytest tests/test_spec_registration.py tests/test_flask_config.py::test_hidden_patch_and_auto_schemas -q`
- `pytest` *(fails: NameError in `generate_refresh_token` and related JWT tests)*


------
https://chatgpt.com/codex/tasks/task_e_689de98a061483229e2bcbf538c7d6d5