### PR TITLE
feat(create-graphql-module-with-sqlalchemy-models): feat(graphql): add GraphQL support with helper and docs

### DIFF
--- a/demo/graphql/README.md
+++ b/demo/graphql/README.md
@@ -1,0 +1,9 @@
+# GraphQL Demo
+
+This example shows how to expose SQLAlchemy models via GraphQL using `flarchitect`.
+
+```bash
+python demo/graphql/load.py
+```
+
+Navigate to `http://localhost:5000/graphql` and issue GraphQL queries and mutations.

--- a/demo/graphql/load.py
+++ b/demo/graphql/load.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Minimal GraphQL demo using flarchitect."""
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from flarchitect import Architect
+from flarchitect.graphql import create_schema_from_models
+
+
+class BaseModel(DeclarativeBase):
+    """Base model for the demo."""
+
+
+app = Flask(__name__)
+app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+app.config["API_TITLE"] = "GraphQL Demo"
+app.config["API_VERSION"] = "1.0"
+app.config["API_BASE_MODEL"] = BaseModel
+
+db = SQLAlchemy(model_class=BaseModel)
+
+
+class Item(db.Model):
+    """Simple item model exposed via GraphQL."""
+
+    __tablename__ = "item"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String)
+
+
+with app.app_context():
+    db.init_app(app)
+    db.create_all()
+    architect = Architect(app)
+    schema = create_schema_from_models([Item], db.session)
+    architect.init_graphql(schema=schema)
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/docs/source/graphql.rst
+++ b/docs/source/graphql.rst
@@ -1,0 +1,21 @@
+GraphQL
+=======
+
+`flarchitect` can expose SQLAlchemy models through a GraphQL API. The
+:func:`flarchitect.graphql.create_schema_from_models` helper builds a Graphene
+schema from your models, while :meth:`flarchitect.Architect.init_graphql`
+registers a ``/graphql`` endpoint and documents it in the OpenAPI spec.
+
+.. code-block:: python
+
+   schema = create_schema_from_models([User], db.session)
+   architect.init_graphql(schema=schema)
+
+Trade-offs
+----------
+
+GraphQL offers flexible queries and reduces the number of HTTP round-trips, but
+it also introduces additional complexity. Responses are not cacheable by
+standard HTTP mechanisms, and naive schemas can allow very expensive queries.
+Ensure resolvers validate user input and consider depth limiting or query cost
+analysis for production deployments.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ flarchitect
    validation
    extensions
    openapi
+   graphql
    error_handling
 
 .. toctree::

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -12,7 +12,7 @@ from flask import Flask, Response, jsonify, request
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from marshmallow import Schema
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, Session
 
 if TYPE_CHECKING:  # pragma: no cover - used for type checkers only
     from flask_caching import Cache
@@ -319,6 +319,66 @@ class Architect(AttributeInitializerMixin):
             **kwargs (dict): Dictionary of keyword arguments.
         """
         self.api = RouteCreator(architect=self, **kwargs)
+
+    def init_graphql(
+        self,
+        schema: Any | None = None,
+        *,
+        models: list[type[DeclarativeBase]] | None = None,
+        session: Session | None = None,
+        url_path: str = "/graphql",
+    ) -> None:
+        """Register a GraphQL endpoint and document it in the OpenAPI spec.
+
+        Args:
+            schema: Prebuilt Graphene schema. If ``None``, ``models`` and
+                ``session`` must be provided to build one automatically.
+            models: Models to expose via GraphQL when ``schema`` is ``None``.
+            session: SQLAlchemy session for resolver functions.
+            url_path: URL path where the GraphQL endpoint should live.
+
+        Raises:
+            ValueError: If a schema is not supplied and models or session are
+                missing.
+        """
+
+        if schema is None:
+            if not models or session is None:
+                raise ValueError("Provide a schema or models and session")
+            from flarchitect.graphql import create_schema_from_models
+
+            schema = create_schema_from_models(models, session)
+
+        @self.app.route(url_path, methods=["GET", "POST"])
+        def graphql_endpoint() -> Response:
+            """Handle GraphQL queries and mutations."""
+
+            if request.method == "GET":
+                return jsonify({"message": "Send a POST request with a GraphQL query."})
+
+            payload = request.get_json(silent=True) or {}
+            result = schema.execute(
+                payload.get("query"),
+                variable_values=payload.get("variables"),
+            )
+            response_data: dict[str, Any] = {}
+            if result.errors:
+                response_data["errors"] = [str(err) for err in result.errors]
+            if result.data is not None:
+                response_data["data"] = result.data
+            return jsonify(response_data)
+
+        route = {
+            "function": graphql_endpoint,
+            "summary": "GraphQL endpoint",
+            "description": "Execute GraphQL queries and mutations.",
+            "tag": "GraphQL",
+        }
+        self.set_route(route)
+        if self.api_spec is not None:
+            from flarchitect.specs.generator import register_routes_with_spec
+
+            register_routes_with_spec(self, [route])
 
     def to_api_spec(self):
         """

--- a/flarchitect/graphql/__init__.py
+++ b/flarchitect/graphql/__init__.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+"""Utilities for converting SQLAlchemy models into GraphQL schemas."""
+
+from collections.abc import Iterable
+from typing import Any
+
+import graphene
+from sqlalchemy import Boolean, Float, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Session
+
+__all__ = ["create_schema_from_models"]
+
+SQLA_TYPE_MAPPING = {
+    Integer: graphene.Int,
+    String: graphene.String,
+    Boolean: graphene.Boolean,
+    Float: graphene.Float,
+}
+
+
+def _convert_sqla_type(column_type: Any) -> type[graphene.Scalar]:
+    """Map a SQLAlchemy column type to a Graphene scalar.
+
+    Args:
+        column_type: SQLAlchemy column type instance.
+
+    Returns:
+        The corresponding Graphene scalar type. Defaults to ``graphene.String``.
+    """
+
+    for sa_type, gql_type in SQLA_TYPE_MAPPING.items():
+        if isinstance(column_type, sa_type):
+            return gql_type
+    return graphene.String
+
+
+def _model_to_object_type(model: type[DeclarativeBase]) -> type[graphene.ObjectType]:
+    """Create a Graphene ``ObjectType`` for a given SQLAlchemy model.
+
+    Args:
+        model: SQLAlchemy declarative model.
+
+    Returns:
+        A dynamically generated ``ObjectType`` subclass.
+    """
+
+    fields: dict[str, Any] = {}
+    for column in model.__table__.columns:  # type: ignore[attr-defined]
+        gql_type = _convert_sqla_type(column.type)
+        fields[column.name] = gql_type()
+
+    return type(f"{model.__name__}Type", (graphene.ObjectType,), fields)
+
+
+def create_schema_from_models(
+    models: Iterable[type[DeclarativeBase]], session: Session
+) -> graphene.Schema:
+    """Generate a GraphQL schema exposing CRUD-style queries and mutations.
+
+    Args:
+        models: Iterable of SQLAlchemy models to expose.
+        session: Active SQLAlchemy session used in resolvers.
+
+    Returns:
+        A Graphene :class:`~graphene.Schema` object with generated Query and
+        Mutation types for the provided models.
+    """
+
+    object_types = {model: _model_to_object_type(model) for model in models}
+
+    query_fields: dict[str, Any] = {}
+    for model, obj_type in object_types.items():
+        name = model.__tablename__
+        query_fields[name] = graphene.Field(obj_type, id=graphene.Int(required=True))
+        query_fields[f"all_{name}s"] = graphene.List(obj_type)
+
+        def _resolve_one(_root, _info, id: int, model=model):
+            return session.get(model, id)
+
+        def _resolve_all(_root, _info, model=model):
+            return session.query(model).all()
+
+        query_fields[f"resolve_{name}"] = staticmethod(_resolve_one)
+        query_fields[f"resolve_all_{name}s"] = staticmethod(_resolve_all)
+
+    Query = type("Query", (graphene.ObjectType,), query_fields)
+
+    mutation_fields: dict[str, Any] = {}
+    for model, obj_type in object_types.items():
+        arguments: dict[str, Any] = {}
+        for column in model.__table__.columns:  # type: ignore[attr-defined]
+            if column.primary_key:
+                continue
+            gql_type = _convert_sqla_type(column.type)
+            arguments[column.name] = gql_type(required=not column.nullable)
+
+        Arguments = type("Arguments", (), arguments)
+
+        def _mutate(_root, _info, model=model, **kwargs):
+            instance = model(**kwargs)
+            session.add(instance)
+            session.commit()
+            return instance
+
+        mutation = type(
+            f"Create{model.__name__}",
+            (graphene.Mutation,),
+            {
+                "Arguments": Arguments,
+                "Output": obj_type,
+                "mutate": staticmethod(_mutate),
+            },
+        )
+
+        mutation_fields[f"create_{model.__tablename__}"] = mutation.Field()
+
+    Mutation = type("Mutation", (graphene.ObjectType,), mutation_fields)
+
+    return graphene.Schema(query=Query, mutation=Mutation, auto_camelcase=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,9 @@ dev = [
 cache = [
   "flask-caching>=2.1.0",
 ]
+graphql = [
+  "graphene>=3.3",
+]
 [tool.ruff]
 exclude = ["./tests", ".bzr", ".direnv", ".eggs", ".git", "./frontend/*", ".git-rewrite", ".hg", ".mypy_cache", ".nox", ".pants.d", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "buck-out", "dist", "node_modules", ".venv"]
 fix = true

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Tests for GraphQL integration."""
+
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+from flarchitect import Architect
+from flarchitect.graphql import create_schema_from_models
+
+
+class Base(DeclarativeBase):
+    """Base declarative model used in tests."""
+
+
+db = SQLAlchemy(model_class=Base)
+
+
+class Item(db.Model):
+    """Simple item model for GraphQL tests."""
+
+    __tablename__ = "item"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String)
+
+
+def create_app() -> Flask:
+    """Create a Flask app configured for testing."""
+
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        API_TITLE="Test API",
+        API_VERSION="1.0",
+        API_BASE_MODEL=Base,
+    )
+
+    with app.app_context():
+        db.init_app(app)
+        db.create_all()
+        arch = Architect(app)
+        schema = create_schema_from_models([Item], db.session)
+        arch.init_graphql(schema=schema)
+
+    return app
+
+
+def test_graphql_query_and_mutation() -> None:
+    """Ensure basic query and mutation operations work."""
+
+    app = create_app()
+    client = app.test_client()
+
+    mutation = {"query": 'mutation { create_item(name: "Foo") { id name } }'}
+    response = client.post("/graphql", json=mutation)
+    assert response.status_code == 200
+    assert response.json["data"]["create_item"]["name"] == "Foo"
+
+    query = {"query": "{ all_items { name } }"}
+    response = client.post("/graphql", json=query)
+    assert response.status_code == 200
+    assert response.json["data"]["all_items"] == [{"name": "Foo"}]
+
+    spec_resp = client.get("/openapi.json")
+    assert "/graphql" in spec_resp.get_json()["paths"]


### PR DESCRIPTION
## Summary
- add GraphQL schema generator mapping SQLAlchemy models
- expose `Architect.init_graphql` to serve `/graphql` and document it in OpenAPI
- document usage, provide demo and tests for basic queries and mutations

## Testing
- `isort flarchitect/core/architect.py flarchitect/graphql/__init__.py demo/graphql/load.py tests/test_graphql.py`
- `black flarchitect/core/architect.py flarchitect/graphql/__init__.py demo/graphql/load.py tests/test_graphql.py`
- `ruff check flarchitect/core/architect.py flarchitect/graphql/__init__.py demo/graphql/load.py tests/test_graphql.py --fix`
- `pytest tests/test_graphql.py`

Labels: feat

------
https://chatgpt.com/codex/tasks/task_e_689de8166ef48322a3476fca3dd684b9