### PR TITLE
docs(graphql): expand GraphQL docs and demo examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If you're new here, welcome! flarchitect gets you from data models to a fully fl
 - **Built-in authentication** – JWT, basic and API key strategies ship with a ready‑made `/auth/login` endpoint, or plug in your own.
 - **Extensibility hooks** – customise request and response flows.
 - **Soft delete** – hide and restore records without permanently removing them.
+- **GraphQL integration** – expose your models through a single `/graphql` endpoint when you need more flexible queries.
 
 ### Optional extras
 
@@ -120,6 +121,30 @@ architect = Architect(app)  # OpenAPI served at /openapi.json, docs serverd at /
 The specification endpoint can be customised with ``API_SPEC_ROUTE``. See the
 [OpenAPI docs](docs/source/openapi.rst) for exporting or customising the
 document.
+
+## GraphQL
+
+Prefer working with a single endpoint? `flarchitect` can turn your SQLAlchemy models into a GraphQL schema with just a couple of lines. Generate the schema and register it with the architect:
+
+```python
+from flarchitect.graphql import create_schema_from_models
+
+schema = create_schema_from_models([Item], db.session)
+architect.init_graphql(schema=schema)
+```
+
+With the server running you can open [GraphiQL](https://github.com/graphql/graphiql) at `http://localhost:5000/graphql` and explore your data interactively.
+
+```graphql
+query {
+    items {
+        id
+        name
+    }
+}
+```
+
+The [GraphQL demo](demo/graphql/README.md) contains ready-made models and sample queries to help you get started.
 
 Read about hiding and restoring records in the [soft delete section](docs/source/advanced_configuration.rst#soft-delete).
 

--- a/demo/graphql/README.md
+++ b/demo/graphql/README.md
@@ -1,9 +1,37 @@
 # GraphQL Demo
 
-This example shows how to expose SQLAlchemy models via GraphQL using `flarchitect`.
+This example shows how to expose SQLAlchemy models via GraphQL using `flarchitect`. It spins up a tiny in-memory database and serves a `/graphql` endpoint.
+
+## Running the demo
 
 ```bash
 python demo/graphql/load.py
 ```
 
-Navigate to `http://localhost:5000/graphql` and issue GraphQL queries and mutations.
+Open `http://localhost:5000/graphql` in your browser to explore the schema with GraphiQL. You can also send queries from the command line using `curl` or `requests`.
+
+## Sample queries
+
+Fetch all items:
+
+```graphql
+query {
+    items {
+        id
+        name
+    }
+}
+```
+
+Create a new item:
+
+```graphql
+mutation {
+    createItem(name: "Biscuit") {
+        id
+        name
+    }
+}
+```
+
+Additional examples, including a small Python client, live alongside this file.

--- a/demo/graphql/client_example.py
+++ b/demo/graphql/client_example.py
@@ -1,0 +1,24 @@
+"""Tiny client demonstrating how to call the GraphQL demo."""
+
+from __future__ import annotations
+
+import requests
+
+
+def main() -> None:
+    """Run a sample query against the demo server."""
+    query = """
+    query {
+        items {
+            id
+            name
+        }
+    }
+    """
+    response = requests.post("http://localhost:5000/graphql", json={"query": query})
+    response.raise_for_status()
+    print(response.json())
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/graphql/load.py
+++ b/demo/graphql/load.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
+"""Run this module to start a tiny GraphQL server powered by flarchitect."""
 
-"""Minimal GraphQL demo using flarchitect."""
+from __future__ import annotations
 
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy

--- a/demo/graphql/sample_queries.graphql
+++ b/demo/graphql/sample_queries.graphql
@@ -1,0 +1,15 @@
+# Fetch all items
+query {
+  items {
+    id
+    name
+  }
+}
+
+# Create a new item
+mutation {
+  createItem(name: "Biscuit") {
+    id
+    name
+  }
+}

--- a/docs/source/graphql.rst
+++ b/docs/source/graphql.rst
@@ -6,16 +6,44 @@ GraphQL
 schema from your models, while :meth:`flarchitect.Architect.init_graphql`
 registers a ``/graphql`` endpoint and documents it in the OpenAPI spec.
 
+Quick start
+-----------
+
+The simplest way to enable GraphQL is to feed your models to
+``create_schema_from_models`` and register the resulting schema with the
+architect:
+
 .. code-block:: python
 
    schema = create_schema_from_models([User], db.session)
    architect.init_graphql(schema=schema)
 
-Trade-offs
-----------
+The generated schema provides CRUD-style queries and mutations for each model.
+An ``items`` query returns every ``Item`` and a ``createItem`` mutation adds a
+new record.
+
+Example query
+~~~~~~~~~~~~~
+
+.. code-block:: graphql
+
+   query {
+       items {
+           id
+           name
+       }
+   }
+
+Visit ``/graphql`` in a browser to access the interactive GraphiQL editor, or
+send HTTP ``POST`` requests with a ``query`` payload.
+
+Tips and trade-offs
+-------------------
 
 GraphQL offers flexible queries and reduces the number of HTTP round-trips, but
 it also introduces additional complexity. Responses are not cacheable by
-standard HTTP mechanisms, and naive schemas can allow very expensive queries.
+standard HTTP mechanisms, and naïve schemas can allow very expensive queries.
 Ensure resolvers validate user input and consider depth limiting or query cost
 analysis for production deployments.
+
+Further examples are available in :mod:`demo.graphql`.


### PR DESCRIPTION
## Summary
- expand GraphQL documentation and feature overview
- add sample queries and client in GraphQL demo

## Testing
- `isort demo/graphql/load.py demo/graphql/client_example.py`
- `black demo/graphql/load.py demo/graphql/client_example.py`
- `ruff check --fix demo/graphql`
- `pytest` *(fails: 52 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_689df261e1288322bad40cecd53317de