### PR TITLE
feat(update-publish.yml-workflow-to-skip-publish): chore(workflow): skip publish without version bump

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Stop if version unchanged
         if: steps.v.outputs.new == steps.v.outputs.old
-        run: echo "No version bump (${ { steps.v.outputs.new } }) — skipping publish." && exit 0
+        run: echo "No version bump (${{ steps.v.outputs.new }}) — skipping publish." && exit 0
 
       - name: Build sdist & wheel
         run: |


### PR DESCRIPTION
## Summary
- ensure publish workflow exits when no version bump occurs

## Testing
- `ruff check .` *(fails: Undefined name `store_refresh_token` and others)*
- `black --check .` *(fails: would reformat 46 files)*
- `isort --check-only .` *(fails: imports incorrectly sorted in multiple files)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask_limiter', etc.)*
- `actionlint .github/workflows/publish.yml`

## Labels
- chore

------
https://chatgpt.com/codex/tasks/task_e_689dfb0fe3c483228155a2f7ae95d9ec