### PR TITLE
feat(run-unit-tests-and-fix-failures): fix(auth): correct refresh token storage and config flags

### DIFF
--- a/flarchitect/authentication/jwt.py
+++ b/flarchitect/authentication/jwt.py
@@ -6,7 +6,11 @@ import jwt
 from flask import current_app
 from sqlalchemy.exc import NoResultFound
 
-from flarchitect.authentication.token_store import delete_refresh_token
+from flarchitect.authentication.token_store import (
+    delete_refresh_token,
+    get_refresh_token,
+    store_refresh_token,
+)
 from flarchitect.database.utils import get_primary_keys
 from flarchitect.exceptions import CustomHTTPException
 from flarchitect.utils.config_helpers import get_config_or_model_meta
@@ -239,8 +243,8 @@ def refresh_access_token(refresh_token: str) -> tuple[str, Any]:
 
     # Get user identifiers from stored_token
     pk_field, lookup_field = get_pk_and_lookups()
-    lookup_value = stored_token[lookup_field]
-    pk_value = stored_token[pk_field]
+    lookup_value = stored_token.user_lookup
+    pk_value = stored_token.user_pk
 
     # Get the user model (this is the SQLAlchemy model)
     usr_model_class = get_config_or_model_meta("API_USER_MODEL")
@@ -263,7 +267,6 @@ def refresh_access_token(refresh_token: str) -> tuple[str, Any]:
     new_access_token = generate_access_token(user)
 
     delete_refresh_token(refresh_token)
-    refresh_tokens_store.pop(refresh_token, None)
 
     return new_access_token, user
 

--- a/flarchitect/authentication/token_store.py
+++ b/flarchitect/authentication/token_store.py
@@ -35,15 +35,11 @@ class RefreshToken(Base):
 
 
 _lock = Lock()
-_table_created = False
 
 
 def _ensure_table(session: Session) -> None:
     """Create the refresh token table if it does not exist."""
-    global _table_created
-    if not _table_created:
-        RefreshToken.metadata.create_all(bind=session.get_bind())
-        _table_created = True
+    RefreshToken.metadata.create_all(bind=session.get_bind())
 
 
 def store_refresh_token(

--- a/flarchitect/database/operations.py
+++ b/flarchitect/database/operations.py
@@ -271,9 +271,8 @@ class CrudService:
         elif select_fields:
             query = query.with_entities(*select_fields)
 
-
         if conditions and get_config_or_model_meta(
-            "API_ALLOW_FILTER", model=self.model, default=True
+            "API_ALLOW_FILTERS", model=self.model, default=True
         ):
             query = query.filter(and_(*conditions))
 

--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -359,6 +359,12 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
                 return unauthorized
             return self.architect.to_api_spec()
 
+        @specification.route("swagger.json")
+        def get_legacy_swagger_spec() -> dict | Response | tuple[str, int]:
+            """Serve the Swagger spec at legacy ``swagger.json`` endpoint."""
+
+            return get_swagger_spec()
+
         get_swagger_spec._auth_disabled = True
 
         @specification.route(documentation_url, methods=["GET", "POST"])


### PR DESCRIPTION
## Summary
- fix refresh token persistence and retrieval
- align filter config flag and add legacy Swagger JSON route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689df59162e4832282c66b3b34afef5e