### PR TITLE
feat(update-bullet-in-index.rst): docs(index): clarify CRUD endpoints bullet

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,7 +76,7 @@ Hook it into your `Flask`_ application and you'll have endpoints, schemas and do
 
 What can it do?
 
-* Automatically create CRUD endpoint for your sqlalchemy models.
+* Automatically create CRUD endpoints for your SQLAlchemy models.
 * Generate `Redoc`_ or Swagger UI documentation on the fly - no manual OpenAPI spec needed.
 * Be configured globally in `Flask`_ or per model or method via ``Meta`` attributes in your models.
 * Authenticate users with minimal effort - use JWTs, API keys or Basic Authentication.


### PR DESCRIPTION
## Summary
- update CRUD endpoints bullet to mention SQLAlchemy and pluralize endpoints

## Testing
- `ruff check docs/source/index.rst` *(fails: SyntaxError: Expected a statement)*
- `black --check docs/source/index.rst` *(fails: Cannot parse for target version Python 3.13)*
- `isort --check-only docs/source/index.rst`
- `pytest` *(fails: Interrupted: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689e025254c48322ace18c3bea8edefd