### PR TITLE
docs(installation): document prerequisites, venv setup, and verification

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,9 +1,37 @@
 Installation
 =========================================
 
+Prerequisites
+-------------
+Flarchitect supports Python 3.10 or newer. Ensure Python is available and up to date by checking the version:
+
+.. code-block:: bash
+
+  $ python --version
+
+Set up a virtual environment
+----------------------------
+Using a virtual environment keeps your project's dependencies tidy. Create and activate one:
+
+.. code-block:: bash
+
+  $ python -m venv .venv
+  $ source .venv/bin/activate  # On Windows use: .venv\\Scripts\\activate
+
 Install Flarchitect
 -------------------
-Once the environment is active, install with :program:`pip`::
+Once the environment is active, install with :program:`pip`:
+
+.. code-block:: bash
 
   (.venv) $ pip install flarchitect
 
+Verify the installation
+-----------------------
+Confirm the installation by importing flarchitect and printing its version:
+
+.. code-block:: bash
+
+  (.venv) $ python -c "import flarchitect; print(flarchitect.__version__)"
+
+This quick check ensures Flarchitect is ready to use.


### PR DESCRIPTION
## Summary
- clarify supported Python versions
- add virtual environment creation and activation steps
- show how to install and verify flarchitect

## Testing
- `ruff check .` (fails: E402 module import order)
- `black --check docs/source/installation.rst` (fails: cannot parse RST)
- `isort --check-only docs/source/installation.rst`
- `pytest` (fails: missing dependencies such as flask, jwt, marshmallow)


------
https://chatgpt.com/codex/tasks/task_e_689e0255d3488322a1151daea8d43b40