### PR TITLE
feat(update-readme-and-sample-queries): docs(graphql): update examples to use all_items and create_item

### DIFF
--- a/demo/graphql/README.md
+++ b/demo/graphql/README.md
@@ -16,7 +16,7 @@ Fetch all items:
 
 ```graphql
 query {
-    items {
+    all_items {
         id
         name
     }
@@ -27,7 +27,7 @@ Create a new item:
 
 ```graphql
 mutation {
-    createItem(name: "Biscuit") {
+    create_item(name: "Biscuit") {
         id
         name
     }

--- a/demo/graphql/client_example.py
+++ b/demo/graphql/client_example.py
@@ -6,10 +6,13 @@ import requests
 
 
 def main() -> None:
-    """Run a sample query against the demo server."""
-    query = """
+    """Run a sample query against the demo server.
+
+    Fetches all items using the ``all_items`` query.
+    """
+    query: str = """
     query {
-        items {
+        all_items {
             id
             name
         }

--- a/demo/graphql/sample_queries.graphql
+++ b/demo/graphql/sample_queries.graphql
@@ -1,6 +1,6 @@
 # Fetch all items
 query {
-  items {
+  all_items {
     id
     name
   }
@@ -8,7 +8,7 @@ query {
 
 # Create a new item
 mutation {
-  createItem(name: "Biscuit") {
+  create_item(name: "Biscuit") {
     id
     name
   }


### PR DESCRIPTION
## Summary
- update demo GraphQL docs to showcase `all_items` query and `create_item` mutation
- adjust sample queries and Python client to use new names

## Testing
- `isort demo/graphql/client_example.py -v`
- `black demo/graphql/client_example.py`
- `ruff check demo/graphql/client_example.py`
- `pytest` *(fails: ImportError: cannot import name 'Architect' from 'flarchitect')*


------
https://chatgpt.com/codex/tasks/task_e_689e3b4d270483229168b388bc6df302