### PR TITLE
feat(update-graphql-documentation-terminology): docs(graphql): reflect all_items query and create_item mutation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,11 @@ schema = create_schema_from_models([Item], db.session)
 architect.init_graphql(schema=schema)
 ```
 
-With the server running you can open [GraphiQL](https://github.com/graphql/graphiql) at `http://localhost:5000/graphql` and explore your data interactively.
+With the server running you can open [GraphiQL](https://github.com/graphql/graphiql) at `http://localhost:5000/graphql` and explore your data interactively. Use the `all_items` query to fetch existing records:
 
 ```graphql
 query {
-    items {
+    all_items {
         id
         name
     }

--- a/demo/graphql/README.md
+++ b/demo/graphql/README.md
@@ -12,22 +12,22 @@ Open `http://localhost:5000/graphql` in your browser to explore the schema with 
 
 ## Sample queries
 
-Fetch all items:
+Fetch all items via the `all_items` query:
 
 ```graphql
 query {
-    items {
+    all_items {
         id
         name
     }
 }
 ```
 
-Create a new item:
+Create a new item with the `create_item` mutation:
 
 ```graphql
 mutation {
-    createItem(name: "Biscuit") {
+    create_item(name: "Biscuit") {
         id
         name
     }

--- a/docs/source/graphql.rst
+++ b/docs/source/graphql.rst
@@ -19,8 +19,8 @@ architect:
    architect.init_graphql(schema=schema)
 
 The generated schema provides CRUD-style queries and mutations for each model.
-An ``items`` query returns every ``Item`` and a ``createItem`` mutation adds a
-new record.
+An ``all_items`` query returns every ``Item`` and a ``create_item`` mutation adds
+a new record.
 
 Example mutation
 ~~~~~~~~~~~~~~~~
@@ -44,7 +44,7 @@ Example query
 .. code-block:: graphql
 
    query {
-       items {
+       all_items {
            id
            name
        }


### PR DESCRIPTION
## Summary
- update GraphQL docs to use `all_items` query and `create_item` mutation
- align README and demo with generated schema terminology

## Testing
- `ruff check flarchitect --no-fix` (fails: Import block is un-sorted or un-formatted)
- `black --check flarchitect/graphql/__init__.py`
- `isort --check-only flarchitect/graphql/__init__.py` (fails: Imports are incorrectly sorted and/or formatted)
- `pytest` (fails: Interrupted: 57 errors during collection)

labels: docs

------
https://chatgpt.com/codex/tasks/task_e_689e3b4c4ab083228d0f13d7e95813e0