### PR TITLE
feat(update-documentation-for-/api/authors): docs(docs): reference /api/authors endpoint

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -3,7 +3,7 @@ Getting Started Sample Project
 
 Flarchitect ships with a tiny demo that shows how it turns a SQLAlchemy model into a REST API.
 The sample lives in ``demo/quickstart/load.py`` and defines a single ``Author`` model.
-Running the script starts a local server and exposes the model at ``/api/author``, returning an empty list until you add data.
+Running the script starts a local server and exposes the model at ``/api/authors``, returning an empty list until you add data.
 
 .. literalinclude:: ../../demo/quickstart/load.py
    :language: python
@@ -15,7 +15,7 @@ Run the demo
 .. code-block:: bash
 
    python demo/quickstart/load.py
-   curl http://localhost:5000/api/author
+   curl http://localhost:5000/api/authors
 
 The curl command answers with a JSON payload that includes some metadata and a ``value`` list of authors.
 Because the demo starts with no records, that list is empty:

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -81,7 +81,7 @@ Use ``curl`` to call an endpoint and view the response.
 
 .. code:: bash
 
-    curl http://localhost:5000/api/author
+    curl http://localhost:5000/api/authors
 
 Example response:
 


### PR DESCRIPTION
## Summary
- update quickstart curl example to use `/api/authors`
- revise getting started guide to reference `/api/authors`

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat many files)*
- `isort --check-only .` *(fails: imports unsorted in many files)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_689e3b4c48b48322b4201e3068f4469e