### PR TITLE
feat(edit-the-faq-documentation-for-clarity): docs(faq): clarify soft delete config values

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -74,10 +74,10 @@ FAQ
     If you need to perform soft deletes, you can use the `API_SOFT_DELETE <configuration.html#SOFT_DELETE>`_ configuration
     as a `Flask`_ global configuration. See :ref:`soft-delete` for an example.
 
-    Additional configuration values to set the attribute that holds the delete flag and the value that represents the
-    ``active`` and ``deleted`` value is also needed.
-
-    See the below configuration values that can be defined globally as `Flask`_ configurations or on a model level.
+    Additional configuration values are needed to specify the attribute storing
+    the delete flag and the values representing the ``active`` and ``deleted``
+    states. See the below configuration values that can be defined globally as
+    `Flask`_ configurations or on a model level.
 
         `API_SOFT_DELETE_ATTRIBUTE <configuration.html#SOFT_DELETE_ATTRIBUTE>`_
 


### PR DESCRIPTION
## Summary
- clarify soft delete configuration sentence in FAQ

## Testing
- `ruff check docs/source --exit-zero`
- `black --check docs/source -v` *(fails: would reformat docs/source/conf.py)*
- `isort --check-only docs/source` *(fails: imports unsorted in docs/source/conf.py)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689e3b4074148322bfdd7f32da49c968