### PR TITLE
feat(update-readme.md-for-uk-spelling): docs(readme): correct licence wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ To publish a new release:
 
 Ensure the repository has a `PYPI_API_TOKEN` secret with an API token from PyPI.
 
-## License
+## Licence
 
-Distributed under the MIT License. See [LICENCE](LICENCE) for details.
+Distributed under the MIT Licence. See [LICENCE](LICENCE) for details.
 


### PR DESCRIPTION
## Summary
- update licence section to use UK spelling

## Testing
- `ruff check --no-fix .` (fails: I001 Import block is un-sorted or un-formatted)
- `black --check flarchitect` (fails: would reformat 8 files)
- `isort --check-only flarchitect` (fails: multiple files with incorrectly sorted imports)
- `pytest` (fails: ModuleNotFoundError: No module named 'flask')

------
https://chatgpt.com/codex/tasks/task_e_689e3b3dbea0832280a6f82ad1a7c561