### PR TITLE
feat(add-repository-root-to-sys.path): test(conftest): add repository root to sys.path

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on sys.path when running tests from subdirectories.
+ROOT_DIR: Path = Path(__file__).resolve().parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))


### PR DESCRIPTION
## Summary
- ensure repository root is inserted into `sys.path` for pytest

## Testing
- `isort conftest.py`
- `black conftest.py`
- `ruff check conftest.py`
- `pytest -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_689e3fb567c08322a9f619d814ca5399