### PR TITLE
feat(create-tests/conftest.py-and-verify-imports): test(conftest): add project root to sys.path for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest configuration to add project root to sys.path."""
+
+import sys
+from pathlib import Path
+
+# Resolve root directory of repository.
+ROOT_DIR: Path = Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))


### PR DESCRIPTION
## Summary
- ensure tests can import project modules by adding project root to sys.path in tests/conftest.py

## Testing
- `ruff check tests/conftest.py`
- `python -m isort tests/conftest.py`
- `python -m black tests/conftest.py`
- `pytest tests/test_architect_helpers.py::test_handle_auth_custom tests/test_version.py::test_version_matches_package -q`

Labels: test

------
https://chatgpt.com/codex/tasks/task_e_689e463b23e48322b1bd5c6e2894ea4d