### PR TITLE
fix(redoc-loading-error-ux6b5p): fix(specs): avoid patch schema references

### DIFF
--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -31,6 +31,22 @@ from flarchitect.utils.general import (
 )
 
 
+def schema_name_resolver(schema: Schema) -> str:
+    """Resolve a schema name based on configuration.
+
+    Args:
+        schema (Schema): Schema instance or class whose name requires resolving.
+
+    Returns:
+        str: The schema name converted using ``API_SCHEMA_CASE``.
+    """
+
+    schema_cls = schema if isinstance(schema, type) else schema.__class__
+    model = getattr(getattr(schema_cls, "Meta", None), "model", None)
+    case = get_config_or_model_meta("API_SCHEMA_CASE", model=model, default="camel")
+    return convert_case(schema_cls.__name__.replace("Schema", ""), case)
+
+
 def scrape_extra_info_from_spec_data(
     spec_data: dict[str, Any],
     method: str,
@@ -238,28 +254,22 @@ def generate_additional_query_params(
 
 def _add_request_body_to_spec_template(
     spec_template: dict[str, Any],
-    http_method: str,
+    _http_method: str,
     input_schema: Schema,
-    model: DeclarativeBase | None,
+    _model: DeclarativeBase | None,
 ):
     """Helper function to add a request body to the spec template.
 
     Args:
         spec_template (Dict[str, Any]): The OpenAPI specification template to enhance.
-        http_method (str): The HTTP method (GET, POST, PUT, DELETE, PATCH).
+        _http_method (str): The HTTP method (GET, POST, PUT, DELETE, PATCH).
         input_schema (Schema): The Marshmallow schema for request body validation.
-        model (Optional[DeclarativeBase]): The SQLAlchemy model for database interactions.
+        _model (Optional[DeclarativeBase]): The SQLAlchemy model for database interactions.
 
     Returns:
         None
     """
-    case = get_config_or_model_meta("API_SCHEMA_CASE", model=model, default="camel")
-
-    name = convert_case(
-        ("patch_" if http_method == "PATCH" else "")
-        + input_schema.__name__.replace("Schema", ""),
-        case,
-    )
+    name = schema_name_resolver(input_schema)
 
     spec_template["requestBody"] = {
         "description": f"`{name}` payload.",

--- a/tests/test_flask_config.py
+++ b/tests/test_flask_config.py
@@ -43,6 +43,12 @@ def test_hidden_patch_and_auto_schemas(client) -> None:
     assert "auto" not in schema_names
     assert all(not name.startswith("patch") for name in schema_names)
 
+    for methods in swagger["paths"].values():
+        patch_spec = methods.get("patch")
+        if patch_spec:
+            ref = patch_spec["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+            assert "patch" not in ref.lower()
+
 
 @pytest.fixture
 def app_meth():

--- a/tests/test_nested_schema_refs_case.py
+++ b/tests/test_nested_schema_refs_case.py
@@ -1,0 +1,18 @@
+import json
+
+import pytest
+
+from demo.model_extension.model import create_app as create_app_models
+from flarchitect.utils.core_utils import convert_case
+
+
+@pytest.mark.parametrize("case", ["camel", "pascal"])
+def test_nested_schema_refs_follow_case(case: str) -> None:
+    app = create_app_models({"API_SCHEMA_CASE": case})
+    client = app.test_client()
+    spec = client.get("/apispec.json").json
+    spec_str = json.dumps(spec)
+    expected = convert_case("Category", case)
+    unexpected = "Category" if expected == "category" else "category"
+    assert f"#/components/schemas/{expected}" in spec_str
+    assert f"#/components/schemas/{unexpected}" not in spec_str


### PR DESCRIPTION
## Summary
- drop patch schema prefix to prevent unresolved references in generated OpenAPI docs
- assert PATCH endpoints reuse base schema names

## Testing
- `python -m ruff check flarchitect/specs/utils.py`
- `python -m black --line-length 200 --check flarchitect/specs/utils.py tests/test_flask_config.py` *(fails: would reformat flarchitect/specs/utils.py)*
- `python -m isort flarchitect/specs/utils.py tests/test_flask_config.py --check-only` *(fails: Imports are incorrectly sorted and/or formatted.)*
- `pytest tests/test_flask_config.py::test_hidden_patch_and_auto_schemas -q`
- `pytest -q` *(fails: ImportError: cannot import name '__version__' from 'flarchitect')*

------
https://chatgpt.com/codex/tasks/task_e_689e46f032708322a9caaa381fcf0931