### PR TITLE
refactor(role-based-authentication-and-update-docs): feat(auth): streamline role-based access and clarify usage

### DIFF
--- a/demo/authentication/README.md
+++ b/demo/authentication/README.md
@@ -88,11 +88,19 @@ see the [authentication docs](../../docs/source/authentication.rst#protecting-ma
 
 To try a demo:
 
-1. Insert a user into the in-memory database using the `User` model.
-2. Start the desired script with `python <file>` (the app listens on port
+1. Insert a user into the in-memory database using the ``User`` model. Roles
+   can be stored on the ``roles`` attribute, e.g.
+
+   ```python
+   from demo.authentication.app_base import User, db
+   with db.session.begin():
+       db.session.add(User(username="alice", password="wonderland", roles=["admin"]))
+   ```
+
+2. Start the desired script with ``python <file>`` (the app listens on port
    ``5000``).
-3. Use the sample curl commands below to authenticate and access the protected
-   `/profile` endpoint.
+3. Use the sample curl commands below to authenticate and access protected
+   endpoints.
 
 ### JWT – [jwt_auth.py](jwt_auth.py)
 
@@ -122,3 +130,13 @@ curl -H "Authorization: Api-Key secret" \
 
 An additional [custom_auth.py](custom_auth.py) example shows how to plug in a
 bespoke authentication callable.
+
+### Role-based access – [jwt_auth.py](jwt_auth.py)
+
+```
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"username":"alice","password":"wonderland"}' \
+  http://localhost:5000/jwt-login
+curl -H "Authorization: Bearer <access-token>" \
+  http://localhost:5000/admin
+```

--- a/demo/authentication/app_base.py
+++ b/demo/authentication/app_base.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import JSON
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 from flarchitect import Architect
@@ -30,6 +31,7 @@ class User(db.Model):
     username: Mapped[str] = mapped_column(unique=True)
     password: Mapped[str] = mapped_column()
     api_key: Mapped[str | None] = mapped_column(nullable=True)
+    roles: Mapped[list[str]] = mapped_column(JSON, default=list)
 
     def check_password(self, candidate: str) -> bool:
         """Compare stored password with ``candidate``.

--- a/demo/authentication/jwt_auth.py
+++ b/demo/authentication/jwt_auth.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from flask import request
 
 from demo.authentication.app_base import BaseConfig, User, create_app
+from flarchitect.authentication import require_roles
 from flarchitect.authentication.jwt import generate_access_token, generate_refresh_token
 from flarchitect.authentication.user import get_current_user
+from flarchitect.core.architect import jwt_authentication
 from flarchitect.exceptions import CustomHTTPException
 
 
@@ -62,6 +64,7 @@ def login() -> dict[str, str]:
 
 
 @app.get("/profile")
+@jwt_authentication
 def profile() -> dict[str, str]:
     """Return the current user's profile.
 
@@ -71,3 +74,13 @@ def profile() -> dict[str, str]:
 
     user = get_current_user()
     return {"username": user.username}
+
+
+@app.get("/admin")
+@jwt_authentication
+@require_roles("admin")
+def admin() -> dict[str, str]:
+    """Return data for admin users only."""
+
+    user = get_current_user()
+    return {"username": user.username, "role": "admin"}

--- a/flarchitect/authentication/__init__.py
+++ b/flarchitect/authentication/__init__.py
@@ -1,5 +1,5 @@
 """Authentication helpers and decorators."""
 
-from .roles import roles_accepted, roles_required
+from .roles import require_roles, roles_accepted, roles_required
 
-__all__ = ["roles_required", "roles_accepted"]
+__all__ = ["require_roles", "roles_required", "roles_accepted"]

--- a/flarchitect/authentication/roles.py
+++ b/flarchitect/authentication/roles.py
@@ -1,3 +1,5 @@
+"""Role-based access control decorators."""
+
 from collections.abc import Callable
 from functools import wraps
 from typing import Any, TypeVar, cast
@@ -8,19 +10,20 @@ from flarchitect.exceptions import CustomHTTPException
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def roles_required(*roles: str) -> Callable[[F], F]:
-    """Restrict access to users possessing specific roles.
+def require_roles(*roles: str, any_of: bool = False) -> Callable[[F], F]:
+    """Enforce role-based access on the decorated function.
 
     Args:
-        *roles: Variable length argument list of role names required to access
-            the decorated endpoint.
+        *roles: Role names to validate against ``current_user.roles``.
+        any_of: When ``True`` any listed role grants access. Defaults to
+            ``False`` requiring *all* roles.
 
     Returns:
-        Callable[[F], F]: A decorator enforcing role-based access control.
+        Callable[[F], F]: A decorator enforcing the role check.
 
     Raises:
-        CustomHTTPException: Raised with status code ``401`` when no user is
-            authenticated or ``403`` when the user lacks the required roles.
+        CustomHTTPException: ``401`` when no user is authenticated or ``403``
+            when roles do not match.
     """
 
     def decorator(func: F) -> F:
@@ -29,62 +32,49 @@ def roles_required(*roles: str) -> Callable[[F], F]:
             user = get_current_user()
             if user is None:
                 raise CustomHTTPException(
-                    status_code=401, reason="Authentication required"
+                    status_code=401,
+                    reason="Authentication required",
                 )
 
-            user_roles = getattr(user, "roles", None)
-            if roles and not set(roles).issubset(set(user_roles or [])):
-                raise CustomHTTPException(status_code=403, reason="Insufficient role")
+            user_roles = set(getattr(user, "roles", []) or [])
+            required = set(roles)
+
+            if required:
+                if any_of and not required.intersection(user_roles):
+                    raise CustomHTTPException(
+                        status_code=403,
+                        reason="Insufficient role",
+                    )
+                if not any_of and not required.issubset(user_roles):
+                    raise CustomHTTPException(
+                        status_code=403,
+                        reason="Insufficient role",
+                    )
 
             return func(*args, **kwargs)
 
         if not hasattr(wrapper, "_decorators"):
             wrapper._decorators = []  # type: ignore[attr-defined]
-        decorator.__name__ = "roles_required"
+        decorator.__name__ = "require_roles"
         decorator._args = roles  # type: ignore[attr-defined]
+        decorator._any_of = any_of  # type: ignore[attr-defined]
         wrapper._decorators.append(decorator)  # type: ignore[attr-defined]
 
         return cast(F, wrapper)
 
     return decorator
+
+
+def roles_required(*roles: str) -> Callable[[F], F]:
+    """Backward compatible wrapper requiring all listed roles."""
+
+    return require_roles(*roles)
 
 
 def roles_accepted(*roles: str) -> Callable[[F], F]:
-    """Allow access when the user has any matching role.
+    """Backward compatible wrapper requiring any of the listed roles."""
 
-    Args:
-        *roles: Variable length argument list of role names any of which
-            will grant access to the decorated endpoint.
+    return require_roles(*roles, any_of=True)
 
-    Returns:
-        Callable[[F], F]: A decorator enforcing role-based access control.
 
-    Raises:
-        CustomHTTPException: Raised with status code ``401`` when no user is
-            authenticated or ``403`` when the user lacks all provided roles.
-    """
-
-    def decorator(func: F) -> F:
-        @wraps(func)
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            user = get_current_user()
-            if user is None:
-                raise CustomHTTPException(
-                    status_code=401, reason="Authentication required"
-                )
-
-            user_roles = getattr(user, "roles", None)
-            if roles and not set(roles).intersection(set(user_roles or [])):
-                raise CustomHTTPException(status_code=403, reason="Insufficient role")
-
-            return func(*args, **kwargs)
-
-        if not hasattr(wrapper, "_decorators"):
-            wrapper._decorators = []  # type: ignore[attr-defined]
-        decorator.__name__ = "roles_accepted"
-        decorator._args = roles  # type: ignore[attr-defined]
-        wrapper._decorators.append(decorator)  # type: ignore[attr-defined]
-
-        return cast(F, wrapper)
-
-    return decorator
+__all__ = ["require_roles", "roles_required", "roles_accepted"]

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -666,7 +666,7 @@ class Architect(AttributeInitializerMixin):
             group_tag: Group name. Defaults to ``None``.
             many: Indicates if multiple items are returned. Defaults to ``False``.
             roles: Roles required to access the endpoint. When truthy and
-                authentication is enabled, the :func:`roles_required` decorator
+                authentication is enabled, the :func:`require_roles` decorator
                 is applied. Defaults to ``False``.
             kwargs: Additional keyword arguments.
 
@@ -685,7 +685,7 @@ class Architect(AttributeInitializerMixin):
             local_roles_required = None
             if roles and auth_flag is not False:
                 from flarchitect.authentication import (
-                    roles_required as local_roles_required,
+                    require_roles as local_roles_required,
                 )
 
             @wraps(f)
@@ -721,8 +721,9 @@ class Architect(AttributeInitializerMixin):
                 def _marker() -> None:
                     """Marker function for roles documentation."""
 
-                _marker.__name__ = "roles_required"
+                _marker.__name__ = "require_roles"
                 _marker._args = roles_tuple  # type: ignore[attr-defined]
+                _marker._any_of = False  # type: ignore[attr-defined]
                 wrapped._decorators = getattr(wrapped, "_decorators", [])
                 wrapped._decorators.append(_marker)  # type: ignore[attr-defined]
 

--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -1046,18 +1046,21 @@ def handle_authorization(f: Callable, spec_template: dict[str, Any]):
     Returns:
         None
     """
-    required_roles = None
-    roles_label = None
+    required_roles: tuple[str, ...] | None = None
+    roles_label: str | None = None
 
     if hasattr(f, "_decorators"):
         for decorator in f._decorators:
-            if decorator.__name__ in {"roles_required", "roles_accepted"}:
+            if decorator.__name__ in {
+                "roles_required",
+                "roles_accepted",
+                "require_roles",
+            }:
                 required_roles = decorator._args
-                roles_label = (
-                    "Roles required"
-                    if decorator.__name__ == "roles_required"
-                    else "Roles accepted"
+                any_of = getattr(
+                    decorator, "_any_of", decorator.__name__ == "roles_accepted"
                 )
+                roles_label = "Roles accepted" if any_of else "Roles required"
                 security = spec_template.setdefault("security", [])
                 if not any("bearerAuth" in scheme for scheme in security):
                     security.append({"bearerAuth": []})

--- a/tests/test_roles_required.py
+++ b/tests/test_roles_required.py
@@ -9,17 +9,17 @@ from flask.testing import FlaskClient
 from marshmallow import Schema, fields
 
 from flarchitect import Architect
-from flarchitect.authentication import roles_accepted, roles_required
+from flarchitect.authentication import require_roles
 from flarchitect.authentication.user import set_current_user
 from flarchitect.exceptions import CustomHTTPException
 from flarchitect.specs.utils import handle_authorization
 from flarchitect.utils.response_helpers import create_response
 
 
-def test_roles_required_direct() -> None:
-    """The decorator blocks access when roles are missing."""
+def test_require_roles_all() -> None:
+    """The decorator blocks access when required roles are missing."""
 
-    @roles_required("admin")
+    @require_roles("admin")
     def sample() -> str:
         return "ok"
 
@@ -98,7 +98,7 @@ def test_openapi_documents_roles() -> None:
 
     spec_template = {"parameters": [], "responses": {"401": {"description": ""}}}
 
-    @roles_required("admin", "editor")
+    @require_roles("admin", "editor")
     def view() -> None:  # pragma: no cover - simple callable
         pass
 
@@ -111,10 +111,10 @@ def test_openapi_documents_roles() -> None:
     )
 
 
-def test_roles_accepted_direct() -> None:
-    """Access granted when user has any accepted role."""
+def test_require_roles_any() -> None:
+    """Access granted when user has any matching role."""
 
-    @roles_accepted("admin", "editor")
+    @require_roles("admin", "editor", any_of=True)
     def sample() -> str:
         return "ok"
 
@@ -139,7 +139,7 @@ def test_openapi_documents_roles_accepted() -> None:
 
     spec_template = {"parameters": [], "responses": {"401": {"description": ""}}}
 
-    @roles_accepted("admin", "editor")
+    @require_roles("admin", "editor", any_of=True)
     def view() -> None:  # pragma: no cover - simple callable
         pass
 


### PR DESCRIPTION
## Summary
- unify role-based checks with `require_roles` decorator
- document role requirements in OpenAPI specs
- expand demos and docs with role-restricted examples

## Testing
- `isort flarchitect/authentication/roles.py flarchitect/authentication/__init__.py flarchitect/specs/utils.py flarchitect/core/architect.py tests/test_roles_required.py demo/authentication/app_base.py demo/authentication/jwt_auth.py demo/authentication/README.md docs/source/authentication.rst`
- `black flarchitect/authentication/roles.py flarchitect/authentication/__init__.py flarchitect/specs/utils.py flarchitect/core/architect.py tests/test_roles_required.py demo/authentication/app_base.py demo/authentication/jwt_auth.py`
- `ruff check flarchitect/authentication/roles.py flarchitect/authentication/__init__.py flarchitect/specs/utils.py flarchitect/core/architect.py tests/test_roles_required.py demo/authentication/app_base.py demo/authentication/jwt_auth.py`
- `pytest` *(fails: Interrupted: 58 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689ecfb4b89c832280ef1b1cb7169cab