### PR TITLE
fix(ci): generate coverage badge during docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,12 @@ jobs:
           python -m pip install -e .
           python -m pip install -e ".[docs,dev]"
 
+      - name: Run tests and generate coverage badge
+        run: |
+          pytest --maxfail=1 --disable-warnings \
+                 --cov=. --cov-report=xml
+          coverage-badge -o docs/source/_static/coverage.svg -f
+
       - name: Build HTML
         working-directory: docs
         run: |


### PR DESCRIPTION
## Summary
- run tests and generate coverage badge during docs build

## Testing
- `isort --check-only flarchitect tests demo`
- `black --check flarchitect tests demo`
- `ruff check --no-fix flarchitect tests demo`
- `pytest`

## Labels
- fix

------
https://chatgpt.com/codex/tasks/task_e_689ecf7d3bec83229af605070ac2902b