### PR TITLE
refactor(html_path-to-use-dynamic-computation): refactor(specs): compute html path dynamically

### DIFF
--- a/flarchitect/specs/generator.py
+++ b/flarchitect/specs/generator.py
@@ -29,8 +29,8 @@ from flarchitect.specs.utils import (
 from flarchitect.utils.config_helpers import get_config_or_model_meta
 from flarchitect.utils.general import (
     AttributeInitializerMixin,
-    find_child_from_parent_dir,
     generate_readme_html,
+    get_html_path,
     make_base_dict,
     manual_render_absolute_template,
     pretty_print_dict,
@@ -258,10 +258,14 @@ class CustomSpec(APISpec, AttributeInitializerMixin):
         tag_groups.append({"name": group_name, "tags": [tag_name]})
 
     def _create_specification_blueprint(self) -> None:
-        """Sets up the blueprint to serve the API specification and documentation."""
-        html_path = find_child_from_parent_dir(
-            "src", "html", current_dir=os.path.dirname(os.path.abspath(__file__))
-        )
+        """Sets up the blueprint to serve the API specification and documentation.
+
+        The HTML template directory is resolved dynamically using
+        :func:`~flarchitect.utils.general.get_html_path` to avoid reliance on
+        global state.
+        """
+
+        html_path = get_html_path()
 
         specification = Blueprint(
             "specification",

--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -8,15 +8,12 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pytz
-from flask import current_app
 from marshmallow import Schema, fields
 from marshmallow_sqlalchemy.fields import Nested, Related, RelatedList
 from sqlalchemy.orm import DeclarativeBase
 from werkzeug.http import HTTP_STATUS_CODES
 from werkzeug.routing import IntegerConverter, UnicodeConverter
 
-import flarchitect.utils
-import flarchitect.utils.decorators
 from flarchitect.database.inspections import get_model_columns, get_model_relationships
 from flarchitect.database.utils import AGGREGATE_FUNCS
 from flarchitect.logging import logger
@@ -25,7 +22,7 @@ from flarchitect.utils.core_utils import convert_case
 from flarchitect.utils.general import (
     DATE_FORMAT,
     DATETIME_FORMAT,
-    html_path,
+    get_html_path,
     manual_render_absolute_template,
     pluralize_last_word,
 )
@@ -726,7 +723,7 @@ def generate_fields_description(schema: Schema) -> str:
             get_table_name(i, resource_name, fields, example_table) for i in range(3)
         ]
 
-        full_path = os.path.join(html_path, "redoc_templates/fields.html")
+        full_path = os.path.join(get_html_path(), "redoc_templates/fields.html")
         schema_name = endpoint_namer(schema.Meta.model)
         api_prefix = get_config_or_model_meta("API_PREFIX", default="/api")
 
@@ -752,7 +749,7 @@ def generate_x_description(template_data: dict, path: str = "") -> str:
         str: Filter examples.
     """
     if template_data:
-        full_path = os.path.join(html_path, path)
+        full_path = os.path.join(get_html_path(), path)
         return manual_render_absolute_template(full_path, **template_data)
     else:
         return "This endpoint does not have a database table (or is computed etc) and should not be filtered\n"
@@ -780,7 +777,7 @@ def generate_filter_examples(schema: Schema) -> str:
     example_one = "&".join(examples[:split_examples])
     example_two = "&".join(examples[-split_examples:])
 
-    full_path = os.path.join(html_path, "redoc_templates/filters.html")
+    full_path = os.path.join(get_html_path(), "redoc_templates/filters.html")
 
     return manual_render_absolute_template(
         full_path, examples=[example_one, example_two]
@@ -853,9 +850,6 @@ def append_parameters(
     Returns:
         None
     """
-    flarchitect.utils.general.html_path = current_app.extensions[
-        "flarchitect"
-    ].get_templates_path()
 
     spec_template.setdefault("parameters", []).extend(path_params + query_params)
     rate_limit = get_config_or_model_meta(

--- a/tests/test_general_get_html_path.py
+++ b/tests/test_general_get_html_path.py
@@ -1,0 +1,53 @@
+"""Tests for ``get_html_path`` helper."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from flask import Flask
+
+# Create minimal stubs so ``general`` can be imported without the full package.
+sys.modules.setdefault("flarchitect", types.ModuleType("flarchitect"))
+utils_mod = types.ModuleType("flarchitect.utils")
+config_helpers = types.ModuleType("flarchitect.utils.config_helpers")
+core_utils = types.ModuleType("flarchitect.utils.core_utils")
+config_helpers.get_config_or_model_meta = lambda *args, **kwargs: None
+core_utils.convert_case = lambda value, case=None: value
+core_utils.get_count = lambda *args, **kwargs: 0
+utils_mod.config_helpers = config_helpers
+utils_mod.core_utils = core_utils
+sys.modules["flarchitect.utils"] = utils_mod
+sys.modules["flarchitect.utils.config_helpers"] = config_helpers
+sys.modules["flarchitect.utils.core_utils"] = core_utils
+
+_general_spec = importlib.util.spec_from_file_location(
+    "general",
+    Path(__file__).resolve().parents[1] / "flarchitect" / "utils" / "general.py",
+)
+assert _general_spec and _general_spec.loader  # for mypy
+_general = importlib.util.module_from_spec(_general_spec)
+_general_spec.loader.exec_module(_general)
+sys.modules["flarchitect.utils.general"] = _general
+
+get_html_path = _general.get_html_path
+
+
+def test_get_html_path_falls_back() -> None:
+    """``get_html_path`` should locate the package ``html`` directory without an app."""
+    path = get_html_path()
+    assert path.endswith("html")
+    assert (Path(path) / "apispec.html").exists()
+
+
+def test_get_html_path_uses_extension() -> None:
+    """``get_html_path`` should use the registered extension when available."""
+    app = Flask(__name__)
+
+    class DummyExt:
+        def get_templates_path(self) -> str:
+            return "/tmp/custom_html"
+
+    app.extensions["flarchitect"] = DummyExt()
+    with app.app_context():
+        assert get_html_path() == "/tmp/custom_html"


### PR DESCRIPTION
## Summary
- replace global `html_path` with `get_html_path` helper
- update spec generator and utilities to use dynamic template lookup
- add tests for `get_html_path`

## Testing
- `pytest tests/test_general_get_html_path.py`


------
https://chatgpt.com/codex/tasks/task_e_689ed3fe90288322a31fa55b8537c6bd