### PR TITLE
feat(add-error-response-helper-and-extend-responses): feat(specs): add error response helper with links

### DIFF
--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -29,6 +29,7 @@ from flarchitect.utils.general import (
     manual_render_absolute_template,
     pluralize_last_word,
 )
+from flarchitect.utils.response_helpers import create_response
 
 
 def schema_name_resolver(schema: Schema) -> str:
@@ -310,58 +311,95 @@ def _add_response_to_spec_template(
     )
 
 
+def build_error_response(
+    status_code: int, links: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    """Build a standardised error response for the OpenAPI specification.
+
+    Args:
+        status_code (int): HTTP status code representing the error.
+        links (Optional[Dict[str, Any]]): Optional OpenAPI links related to the error.
+
+    Returns:
+        Dict[str, Any]: Response block including example payload.
+    """
+    example = create_response(
+        status=status_code, errors={"error": HTTP_STATUS_CODES.get(status_code)}
+    ).get_json()
+
+    response: dict[str, Any] = {
+        "description": HTTP_STATUS_CODES.get(status_code),
+        "content": {"application/json": {"example": example}},
+    }
+
+    if links:
+        response["links"] = links
+
+    return response
+
+
 def _initialize_base_responses(
-    method: str, many: bool, error_responses: list[int]
+    method: str,
+    many: bool,
+    error_responses: list[int],
+    links: dict[int, dict[str, Any]] | None = None,
 ) -> dict[str, dict[str, Any]]:
-    """Helper function to initialise base responses.
+    """Initialise base responses for a route.
 
     Args:
         method (str): The HTTP method.
         many (bool): Whether the endpoint returns multiple items.
         error_responses (List[int]): List of error response status codes.
+        links (Optional[Dict[int, Dict[str, Any]]]): Links for specific error responses.
 
     Returns:
         Dict[str, Dict[str, Any]]: Dictionary of base responses.
     """
+    links = links or {}
     responses = {"200": {"description": "Successful operation"}}
 
     if 500 in error_responses or not error_responses:
-        responses["500"] = {"description": HTTP_STATUS_CODES.get(500)}
+        responses["500"] = build_error_response(500, links.get(500))
 
     if (
         method != "POST"
         and not many
         and (404 in error_responses or not error_responses)
     ):
-        responses["404"] = {"description": HTTP_STATUS_CODES.get(404)}
+        responses["404"] = build_error_response(404, links.get(404))
 
     if (
         method == "DELETE"
         and not many
         and (409 in error_responses or not error_responses)
     ):
-        responses["409"] = {"description": HTTP_STATUS_CODES.get(409)}
+        responses["409"] = build_error_response(409, links.get(409))
 
     return responses
 
 
-def _initialize_auth_responses(error_responses: list[int]) -> dict[str, dict[str, Any]]:
-    """Helper function to initialise authentication responses.
+def _initialize_auth_responses(
+    error_responses: list[int],
+    links: dict[int, dict[str, Any]] | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Initialise authentication error responses.
 
     Args:
         error_responses (List[int]): List of error response status codes.
+        links (Optional[Dict[int, Dict[str, Any]]]): Links for specific error responses.
 
     Returns:
         Dict[str, Dict[str, Any]]: Dictionary of authentication responses.
     """
     responses = {}
+    links = links or {}
     auth_on = get_config_or_model_meta("API_AUTHENTICATE", default=False)
 
     if auth_on and (403 in error_responses or not error_responses):
-        responses["403"] = {"description": HTTP_STATUS_CODES.get(403)}
+        responses["403"] = build_error_response(403, links.get(403))
 
     if auth_on and (401 in error_responses or not error_responses):
-        responses["401"] = {"description": HTTP_STATUS_CODES.get(401)}
+        responses["401"] = build_error_response(401, links.get(401))
 
     return responses
 
@@ -806,6 +844,7 @@ def initialize_spec_template(
     many: bool = False,
     rate_limit: bool = False,
     error_responses: list[int] | None = None,
+    links: dict[int, dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Initialises the spec template with optional rate limiting headers for successful and rate-limited responses.
 
@@ -814,6 +853,7 @@ def initialize_spec_template(
         many (bool): Whether the endpoint returns multiple items.
         rate_limit (bool): Whether the endpoint has a rate limit.
         error_responses (Optional[List[int]]): List of error response status codes.
+        links (Optional[Dict[int, Dict[str, Any]]]): Links for specific error responses.
 
     Returns:
         Dict[str, Any]: Spec template.
@@ -821,8 +861,12 @@ def initialize_spec_template(
     if not error_responses:
         error_responses = []
 
-    responses = _initialize_base_responses(method, many, error_responses)
-    responses.update(_initialize_auth_responses(error_responses))
+    if links is None:
+        raw_links = get_config_or_model_meta("links", default={}, method=method)
+        links = {int(k): v for k, v in raw_links.items()} if raw_links else {}
+
+    responses = _initialize_base_responses(method, many, error_responses, links)
+    responses.update(_initialize_auth_responses(error_responses, links))
     responses.update(_initialize_rate_limit_responses(rate_limit))
 
     return {"responses": responses, "parameters": []}

--- a/tests/test_spec_error_responses.py
+++ b/tests/test_spec_error_responses.py
@@ -1,0 +1,37 @@
+from flask import Flask
+
+from flarchitect.specs.utils import build_error_response, initialize_spec_template
+
+
+def _make_app() -> Flask:
+    app = Flask(__name__)
+    app.config["API_VERSION"] = "1"
+    app.config["API_AUTHENTICATE"] = True
+    return app
+
+
+def test_build_error_response_includes_example_and_links() -> None:
+    app = _make_app()
+    with app.test_request_context():
+        resp = build_error_response(404, {"about": {"operationId": "getWidget"}})
+        example = resp["content"]["application/json"]["example"]
+        assert resp["description"].lower() == "not found"
+        assert example["status_code"] == 404
+        assert example["errors"] == {"error": "Not Found"}
+        assert resp["links"]["about"]["operationId"] == "getWidget"
+
+
+def test_initialize_spec_template_passes_configured_links() -> None:
+    app = _make_app()
+    app.config["API_LINKS"] = {
+        "404": {"about": {"operationId": "getWidget"}},
+        "401": {"login": {"operationId": "login"}},
+    }
+    with app.test_request_context():
+        spec = initialize_spec_template("GET", error_responses=[404, 401])
+        resp_404 = spec["responses"]["404"]
+        resp_401 = spec["responses"]["401"]
+        assert resp_404["links"]["about"]["operationId"] == "getWidget"
+        assert resp_401["links"]["login"]["operationId"] == "login"
+        assert resp_404["content"]["application/json"]["example"]["status_code"] == 404
+        assert resp_401["content"]["application/json"]["example"]["status_code"] == 401


### PR DESCRIPTION
## Summary
- add helper to build error response examples with optional links
- wire links into base and auth responses and initialization
- cover error response links in spec utilities

## Testing
- `pytest tests/test_spec_error_responses.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689ed77b58a88322bfb284117c68172e