### PR TITLE
feat(add-default-fallbacks-for-openapi-metadata): feat(add-default-fallbacks-for-openapi-metadata): feat(specs): add default examples with config override

### DIFF
--- a/docs/source/_configuration_table.rst
+++ b/docs/source/_configuration_table.rst
@@ -121,6 +121,13 @@ Documentation Settings
           :bdg-secondary:`Optional` :bdg-dark-line:`Global`
 
         - Sets the background colour behind the logo, allowing alignment with corporate branding. Accepts any CSS colour string. Example: `tests/test_flask_config.py <https://github.com/lewis-morris/flarchitect/blob/master/tests/test_flask_config.py>`_.
+    * - ``API_OPENAPI_FIELD_EXAMPLE_DEFAULTS``
+
+          :bdg:`default:` ``{"Integer": 1, "Float": 1.23, "Decimal": 9.99, "Boolean": True}``
+          :bdg:`type` ``dict``
+          :bdg-secondary:`Optional` :bdg-dark-line:`Global`
+
+        - Mapping of Marshmallow field names to example values used when no explicit ``example`` metadata is provided.
     * - ``API_DESCRIPTION``
 
           :bdg:`type` ``str or str path``

--- a/tests/test_openapi_examples.py
+++ b/tests/test_openapi_examples.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from marshmallow import Schema, fields
+
+from demo.basic_factory.basic_factory import create_app
+from flarchitect.specs.utils import get_openapi_meta_data
+
+
+class SampleSchema(Schema):
+    int_field = fields.Integer()
+    float_field = fields.Float()
+    decimal_field = fields.Decimal()
+    bool_field = fields.Boolean()
+
+
+def test_get_openapi_meta_data_defaults() -> None:
+    """get_openapi_meta_data returns placeholder examples when none supplied."""
+    schema = SampleSchema()
+    assert get_openapi_meta_data(schema.fields["int_field"])["example"] == 1
+    assert get_openapi_meta_data(schema.fields["float_field"])["example"] == 1.23
+    assert get_openapi_meta_data(schema.fields["decimal_field"])["example"] == 9.99
+    assert get_openapi_meta_data(schema.fields["bool_field"])["example"] is True
+
+
+def test_spec_has_default_examples() -> None:
+    """Generated OpenAPI spec includes default examples for numeric fields."""
+    app = create_app()
+    client = app.test_client()
+    spec = client.get("/openapi.json").get_json()
+    author_id = spec["components"]["schemas"]["author"]["properties"]["id"]["example"]
+    rating = spec["components"]["schemas"]["review"]["properties"]["rating"]["example"]
+    assert author_id == 1
+    assert rating == 1.23
+
+
+def test_config_override_in_spec() -> None:
+    """Config overrides take precedence over default example placeholders."""
+    app = create_app({"API_OPENAPI_FIELD_EXAMPLE_DEFAULTS": {"Integer": 7}})
+    with app.app_context():
+        assert get_openapi_meta_data(fields.Integer())["example"] == 7


### PR DESCRIPTION
## Summary
- add default numeric and boolean examples when none supplied
- allow overriding OpenAPI example defaults via configuration
- document and test default example behaviour

## Testing
- `ruff check flarchitect/specs/utils.py tests/test_openapi_examples.py --fix`
- `isort flarchitect/specs/utils.py tests/test_openapi_examples.py`
- `black flarchitect/specs/utils.py tests/test_openapi_examples.py`
- `pytest tests/test_decimal_field_metadata.py tests/test_openapi_examples.py`
- `python - <<'PY'
from demo.basic_factory.basic_factory import create_app
app = create_app()
client = app.test_client()
spec = client.get('/openapi.json').get_json()
print('author.id example', spec['components']['schemas']['author']['properties']['id'].get('example'))
print('review.rating example', spec['components']['schemas']['review']['properties']['rating'].get('example'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_689ed77356bc8322b504cfeee1de880b