### PR TITLE
fix(failing-unit-tests-ja1x45): fix(utils): validate rate limit storage URIs and normalize endpoint names

### DIFF
--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -1400,4 +1400,5 @@ def endpoint_namer(
         "API_ENDPOINT_CASE", default="kebab", model=model_obj
     )
     converted_name = convert_case(model_obj.__name__, case)
-    return pluralize_last_word(converted_name)
+    pluralized_name = pluralize_last_word(converted_name)
+    return convert_case(pluralized_name, case)

--- a/flarchitect/utils/general.py
+++ b/flarchitect/utils/general.py
@@ -217,6 +217,8 @@ def check_rate_services() -> str | None:
             "mongodb": "MongoDB",
             "memory": None,
         }
+        if not parsed.scheme or not parsed.netloc:
+            raise ValueError("Rate limit storage URI must include scheme and host")
         if parsed.scheme not in scheme_map:
             raise ValueError(f"Unsupported rate limit storage backend: {parsed.scheme}")
         service_name = scheme_map[parsed.scheme]

--- a/tests/test_rate_limit_services.py
+++ b/tests/test_rate_limit_services.py
@@ -6,10 +6,7 @@ import importlib.util
 
 import pytest
 
-from flarchitect.utils.general import (
-    check_rate_prerequisites,
-    check_rate_services,
-)
+from flarchitect.utils.general import check_rate_prerequisites, check_rate_services
 
 
 class TestRateLimitServices:
@@ -30,7 +27,9 @@ class TestRateLimitServices:
 
         assert check_rate_services() == "redis://127.0.0.1:6379"
 
-    def test_returns_none_without_services(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_none_without_services(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Return ``None`` when no cache services are reachable."""
 
         monkeypatch.setattr(
@@ -51,11 +50,15 @@ class TestRateLimitServices:
             def close(self) -> None:  # pragma: no cover
                 pass
 
-        monkeypatch.setattr("flarchitect.utils.general.socket.socket", lambda *a, **k: DummySocket())
+        monkeypatch.setattr(
+            "flarchitect.utils.general.socket.socket", lambda *a, **k: DummySocket()
+        )
 
         assert check_rate_services() is None
 
-    def test_prerequisites_missing_dependency(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_prerequisites_missing_dependency(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Raise ``ImportError`` if required client library is absent."""
 
         monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
@@ -68,6 +71,18 @@ class TestRateLimitServices:
         monkeypatch.setattr(
             "flarchitect.utils.general.get_config_or_model_meta",
             lambda key, default=None, model=None: "invalid://localhost",
+        )
+        with pytest.raises(ValueError):
+            check_rate_services()
+
+    def test_missing_host_in_storage_uri_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A storage URI without a host should raise ``ValueError``."""
+
+        monkeypatch.setattr(
+            "flarchitect.utils.general.get_config_or_model_meta",
+            lambda key, default=None, model=None: "redis://",
         )
         with pytest.raises(ValueError):
             check_rate_services()

--- a/tests/test_specs_utils.py
+++ b/tests/test_specs_utils.py
@@ -4,7 +4,9 @@ from pathlib import Path
 import pytest
 from flask import Flask
 
-spec_utils_path = Path(__file__).resolve().parents[1] / "flarchitect" / "specs" / "utils.py"
+spec_utils_path = (
+    Path(__file__).resolve().parents[1] / "flarchitect" / "specs" / "utils.py"
+)
 spec_utils_spec = importlib.util.spec_from_file_location("spec_utils", spec_utils_path)
 spec_utils_module = importlib.util.module_from_spec(spec_utils_spec)
 assert spec_utils_spec.loader is not None  # for mypy
@@ -64,3 +66,15 @@ def test_endpoint_namer_accepts_model_and_schemas() -> None:
         assert endpoint_namer(output_schema=OutputSchema) == "widgets"
         with pytest.raises(ValueError):
             endpoint_namer()
+
+
+def test_endpoint_namer_respects_config_case(monkeypatch: pytest.MonkeyPatch) -> None:
+    """endpoint_namer should honour ``API_ENDPOINT_CASE`` setting."""
+
+    class Widget:
+        pass
+
+    app = Flask(__name__)
+    with app.app_context():
+        app.config["API_ENDPOINT_CASE"] = "pascal"
+        assert endpoint_namer(Widget) == "Widgets"


### PR DESCRIPTION
## Summary
- validate rate limit storage URIs and reject malformed entries
- ensure endpoint_namer re-applies configured casing after pluralization
- add regression tests for URI validation and endpoint naming

## Testing
- `ruff check flarchitect/utils/general.py flarchitect/specs/utils.py tests/test_rate_limit_services.py tests/test_specs_utils.py`
- `black flarchitect/utils/general.py flarchitect/specs/utils.py tests/test_rate_limit_services.py tests/test_specs_utils.py`
- `pytest tests/test_rate_limit_services.py tests/test_specs_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689ee3ca79fc8322a97952972f776986