### PR TITLE
feat(modify-create_schema_from_models-for-filters-and-pagination): feat(graphql): add filters and pagination to list queries

### DIFF
--- a/docs/source/graphql.rst
+++ b/docs/source/graphql.rst
@@ -19,8 +19,9 @@ architect:
    architect.init_graphql(schema=schema)
 
 The generated schema provides CRUD-style queries and mutations for each model.
-An ``all_items`` query returns every ``Item`` and a ``create_item`` mutation adds
-a new record.
+An ``all_items`` query returns every ``Item`` and accepts optional column
+arguments for filtering. Pagination is supported via ``limit`` and
+``offset`` arguments, and a ``create_item`` mutation adds a new record.
 
 Example mutation
 ~~~~~~~~~~~~~~~~
@@ -44,7 +45,19 @@ Example query
 .. code-block:: graphql
 
    query {
-       all_items {
+       all_items(name: "Foo", limit: 1, offset: 0) {
+           id
+           name
+       }
+   }
+
+Filtering on any column is supported. The following returns all ``Item``
+objects with ``name`` equal to ``"Bar"``:
+
+.. code-block:: graphql
+
+   query {
+       all_items(name: "Bar") {
            id
            name
        }

--- a/flarchitect/graphql/__init__.py
+++ b/flarchitect/graphql/__init__.py
@@ -25,6 +25,7 @@ as a ``create_item`` mutation that accepts the model's columns as arguments.
 """
 
 from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import Any
 
@@ -104,7 +105,8 @@ def create_schema_from_models(
     Each provided model receives two query fields:
 
     * ``<table_name>(id: ID)`` – fetch a single row by primary key.
-    * ``all_<table_name>s`` – fetch every row in the table.
+    * ``all_<table_name>s`` – fetch rows with optional filters, ``limit`` and
+      ``offset`` arguments.
 
     And one mutation field:
 
@@ -132,17 +134,40 @@ def create_schema_from_models(
     for model, obj_type in object_types.items():
         name = model.__tablename__
         query_fields[name] = graphene.Field(obj_type, id=graphene.Int(required=True))
-        query_fields[f"all_{name}s"] = graphene.List(obj_type)
+
+        # Collect filterable columns for list queries and add pagination args.
+        list_args: dict[str, Any] = {}
+        for column in model.__table__.columns:  # type: ignore[attr-defined]
+            gql_type = _convert_sqla_type(column.type)
+            list_args[column.name] = gql_type()
+        list_args["limit"] = graphene.Int()
+        list_args["offset"] = graphene.Int()
+        query_fields[f"all_{name}s"] = graphene.List(obj_type, **list_args)
 
         def _resolve_one(_root, _info, id: int, model=model):
             """Resolver for fetching a single record by ID."""
 
             return session.get(model, id)
 
-        def _resolve_all(_root, _info, model=model):
-            """Resolver for fetching all records for the model."""
+        def _resolve_all(_root, _info, model=model, **kwargs):
+            """Resolver for fetching records with optional filters and pagination."""
 
-            return session.query(model).all()
+            query = session.query(model)
+            pk = list(model.__table__.primary_key.columns)[0]  # type: ignore[attr-defined]
+            query = query.order_by(pk)
+
+            limit = kwargs.pop("limit", None)
+            offset = kwargs.pop("offset", None)
+            for column, value in kwargs.items():
+                if value is not None:
+                    query = query.filter(getattr(model, column) == value)
+
+            if offset is not None:
+                query = query.offset(offset)
+            if limit is not None:
+                query = query.limit(limit)
+
+            return query.all()
 
         query_fields[f"resolve_{name}"] = staticmethod(_resolve_one)
         query_fields[f"resolve_all_{name}s"] = staticmethod(_resolve_all)

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -66,3 +66,27 @@ def test_graphql_query_and_mutation() -> None:
 
     spec_resp = client.get("/openapi.json")
     assert "/graphql" in spec_resp.get_json()["paths"]
+
+
+def test_graphql_filters_and_pagination() -> None:
+    """Ensure filters and pagination work for list queries."""
+
+    app = create_app()
+    client = app.test_client()
+
+    for name in ["Foo", "Bar", "Baz"]:
+        mutation = {
+            "query": f'mutation {{ create_item(name: "{name}") {{ id name }} }}'
+        }
+        response = client.post("/graphql", json=mutation)
+        assert response.status_code == 200
+
+    query = {"query": '{ all_items(name: "Bar") { name } }'}
+    response = client.post("/graphql", json=query)
+    assert response.status_code == 200
+    assert response.json["data"]["all_items"] == [{"name": "Bar"}]
+
+    query = {"query": "{ all_items(limit: 1, offset: 1) { name } }"}
+    response = client.post("/graphql", json=query)
+    assert response.status_code == 200
+    assert response.json["data"]["all_items"] == [{"name": "Bar"}]


### PR DESCRIPTION
## Summary
- allow `all_<table>s` GraphQL queries to filter by column and paginate via `limit`/`offset`
- document filtering and pagination usage with sample queries
- test filtered and paginated GraphQL queries

## Testing
- `ruff check flarchitect/graphql/__init__.py tests/test_graphql.py`
- `black flarchitect/graphql/__init__.py tests/test_graphql.py`
- `isort flarchitect/graphql/__init__.py docs/source/graphql.rst tests/test_graphql.py`
- `pytest tests/test_graphql.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f05c068e88322b0f6c8bcc4ae0706