### PR TITLE
feat(extend-sqla_type_mapping-and-add-tests): feat(extend-sqla_type_mapping-and-add-tests): feat(graphql): extend type mapping with override support

### DIFF
--- a/docs/source/graphql.rst
+++ b/docs/source/graphql.rst
@@ -22,6 +22,21 @@ The generated schema provides CRUD-style queries and mutations for each model.
 An ``all_items`` query returns every ``Item`` and a ``create_item`` mutation adds
 a new record.
 
+Type mapping
+------------
+
+``create_schema_from_models`` converts SQLAlchemy column types into Graphene
+scalars using :data:`flarchitect.graphql.SQLA_TYPE_MAPPING`. Out of the box it
+supports ``Integer``, ``String``, ``Boolean``, ``Float``, ``Date``, ``DateTime``,
+``Numeric``, ``JSON`` and ``UUID`` columns. Custom or proprietary SQLAlchemy
+types can be mapped by providing a ``type_mapping`` override:
+
+.. code-block:: python
+
+   schema = create_schema_from_models(
+       [User], db.session, type_mapping={MyType: graphene.String}
+   )
+
 Example mutation
 ~~~~~~~~~~~~~~~~
 

--- a/flarchitect/graphql/__init__.py
+++ b/flarchitect/graphql/__init__.py
@@ -1,9 +1,15 @@
 """Helpers for turning SQLAlchemy models into GraphQL schemas.
 
-This module provides a small bridge between SQLAlchemy and the `graphene`
+This module provides a small bridge between SQLAlchemy and the ``graphene``
 library. Given a list of declarative models and an active
 ``sqlalchemy.orm.Session`` it dynamically builds :class:`graphene.ObjectType`
 classes, query fields and mutation fields that expose basic CRUD operations.
+
+The default :data:`SQLA_TYPE_MAPPING` covers common column types such as
+``Integer``, ``String``, ``Boolean``, ``Float``, ``Date``, ``DateTime``,
+``Numeric``, ``JSON`` and ``UUID``. Custom or proprietary SQLAlchemy types can
+be mapped to Graphene scalars by supplying a ``type_mapping`` override to
+:func:`create_schema_from_models`.
 
 Example:
     >>> from sqlalchemy import Integer, String
@@ -25,30 +31,47 @@ as a ``create_item`` mutation that accepts the model's columns as arguments.
 """
 
 from __future__ import annotations
+
 from collections.abc import Iterable
 from typing import Any
 
 import graphene
-from sqlalchemy import Boolean, Float, Integer, String
+from sqlalchemy import (
+    JSON,
+    UUID,
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    Integer,
+    Numeric,
+    String,
+)
 from sqlalchemy.orm import DeclarativeBase, Session
 
 __all__ = ["create_schema_from_models"]
 
 # Mapping of common SQLAlchemy column types to their Graphene scalar
 # counterparts. Extend this dictionary if your models use additional types.
-SQLA_TYPE_MAPPING = {
+SQLA_TYPE_MAPPING: dict[type, type[graphene.Scalar]] = {
     Integer: graphene.Int,
     String: graphene.String,
     Boolean: graphene.Boolean,
     Float: graphene.Float,
+    Date: graphene.Date,
+    DateTime: graphene.DateTime,
+    Numeric: graphene.Decimal,
+    JSON: graphene.JSONString,
+    UUID: graphene.UUID,
 }
 
 
-def _convert_sqla_type(column_type: Any) -> type[graphene.Scalar]:
+def _convert_sqla_type(column_type: Any, type_mapping: dict[type, type[graphene.Scalar]]) -> type[graphene.Scalar]:
     """Map a SQLAlchemy column type to a Graphene scalar.
 
     Args:
         column_type: SQLAlchemy column type instance.
+        type_mapping: Mapping of SQLAlchemy types to Graphene scalars.
 
     Returns:
         Graphene scalar type. Defaults to :class:`graphene.String` when no
@@ -56,17 +79,17 @@ def _convert_sqla_type(column_type: Any) -> type[graphene.Scalar]:
 
     Examples:
         >>> from sqlalchemy import Integer
-        >>> _convert_sqla_type(Integer()) is graphene.Int
+        >>> _convert_sqla_type(Integer(), SQLA_TYPE_MAPPING) is graphene.Int
         True
     """
 
-    for sa_type, gql_type in SQLA_TYPE_MAPPING.items():
+    for sa_type, gql_type in type_mapping.items():
         if isinstance(column_type, sa_type):
             return gql_type
     return graphene.String
 
 
-def _model_to_object_type(model: type[DeclarativeBase]) -> type[graphene.ObjectType]:
+def _model_to_object_type(model: type[DeclarativeBase], type_mapping: dict[type, type[graphene.Scalar]]) -> type[graphene.ObjectType]:
     """Create a Graphene ``ObjectType`` for a given SQLAlchemy model.
 
     The function inspects the model's table and converts each column into a
@@ -74,6 +97,7 @@ def _model_to_object_type(model: type[DeclarativeBase]) -> type[graphene.ObjectT
 
     Args:
         model: SQLAlchemy declarative model.
+        type_mapping: Mapping of SQLAlchemy types to Graphene scalars.
 
     Returns:
         A dynamically generated ``ObjectType`` subclass whose fields mirror the
@@ -83,21 +107,23 @@ def _model_to_object_type(model: type[DeclarativeBase]) -> type[graphene.ObjectT
         >>> class User(Base):
         ...     __tablename__ = "user"
         ...     id: Mapped[int] = mapped_column(primary_key=True)
-        >>> UserType = _model_to_object_type(User)
+        >>> UserType = _model_to_object_type(User, SQLA_TYPE_MAPPING)
         >>> issubclass(UserType, graphene.ObjectType)
         True
     """
 
     fields: dict[str, Any] = {}
     for column in model.__table__.columns:  # type: ignore[attr-defined]
-        gql_type = _convert_sqla_type(column.type)
+        gql_type = _convert_sqla_type(column.type, type_mapping)
         fields[column.name] = gql_type()
 
     return type(f"{model.__name__}Type", (graphene.ObjectType,), fields)
 
 
 def create_schema_from_models(
-    models: Iterable[type[DeclarativeBase]], session: Session
+    models: Iterable[type[DeclarativeBase]],
+    session: Session,
+    type_mapping: dict[type, type[graphene.Scalar]] | None = None,
 ) -> graphene.Schema:
     """Generate a GraphQL schema exposing CRUD-style queries and mutations.
 
@@ -113,6 +139,8 @@ def create_schema_from_models(
     Args:
         models: Iterable of SQLAlchemy models to expose.
         session: Active SQLAlchemy session used in resolvers.
+        type_mapping: Optional mapping of SQLAlchemy types to Graphene scalars
+            that overrides :data:`SQLA_TYPE_MAPPING`.
 
     Returns:
         A Graphene :class:`~graphene.Schema` with the generated ``Query`` and
@@ -125,7 +153,8 @@ def create_schema_from_models(
         []
     """
 
-    object_types = {model: _model_to_object_type(model) for model in models}
+    mapping = {**SQLA_TYPE_MAPPING, **(type_mapping or {})}
+    object_types = {model: _model_to_object_type(model, mapping) for model in models}
 
     # Build query fields for single-record and list retrieval.
     query_fields: dict[str, Any] = {}
@@ -156,7 +185,7 @@ def create_schema_from_models(
         for column in model.__table__.columns:  # type: ignore[attr-defined]
             if column.primary_key:
                 continue
-            gql_type = _convert_sqla_type(column.type)
+            gql_type = _convert_sqla_type(column.type, mapping)
             arguments[column.name] = gql_type(required=not column.nullable)
 
         Arguments = type("Arguments", (), arguments)


### PR DESCRIPTION
## Summary
- expand default SQLAlchemy-to-Graphene type mapping and add override hook
- document type mapping and customization
- test additional type mapping and override functionality

## Testing
- `isort flarchitect/graphql/__init__.py tests/test_graphql.py docs/source/graphql.rst`
- `black flarchitect/graphql/__init__.py tests/test_graphql.py`
- `ruff check flarchitect/graphql/__init__.py tests/test_graphql.py --fix`
- `pytest tests/test_graphql.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f05c3d94c8322b38e0dd65bef5864