### PR TITLE
feat(wrap-mutation-operations-with-error-handling): feat(graphql): provide structured error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ query {
 
 The [GraphQL demo](demo/graphql/README.md) contains ready-made models and sample queries to help you get started.
 
+Errors returned from the endpoint include an ``extensions`` object with a
+``code`` such as ``DATABASE_ERROR`` or ``VALIDATION_ERROR`` and a descriptive
+``detail``. This makes client-side error handling straightforward.
+
 Read about hiding and restoring records in the [soft delete section](docs/source/advanced_configuration.rst#soft-delete).
 
 ## Running Tests

--- a/docs/source/graphql.rst
+++ b/docs/source/graphql.rst
@@ -53,6 +53,28 @@ Example query
 Visit ``/graphql`` in a browser to access the interactive GraphiQL editor, or
 send HTTP ``POST`` requests with a ``query`` payload.
 
+Error handling
+--------------
+
+Resolvers and mutations surface issues as structured GraphQL errors. Database
+problems return ``DATABASE_ERROR`` codes, while invalid input yields
+``VALIDATION_ERROR``. Each error entry includes a short message and a
+``detail`` field for additional context::
+
+   {
+       "errors": [
+           {
+               "message": "Database error",
+               "extensions": {
+                   "code": "DATABASE_ERROR",
+                   "detail": "UNIQUE constraint failed: item.name"
+               }
+           }
+       ]
+   }
+
+Clients can inspect the ``extensions`` map to handle failures consistently.
+
 Tips and trade-offs
 -------------------
 


### PR DESCRIPTION
## Summary
- handle database and validation failures with structured GraphQL errors
- translate execution errors to GraphQL error objects at the endpoint
- document error format and add tests for invalid IDs and constraint issues

## Testing
- `ruff check flarchitect/graphql/__init__.py flarchitect/core/architect.py tests/test_graphql.py`
- `isort --profile black --check flarchitect/core/architect.py flarchitect/graphql/__init__.py tests/test_graphql.py`
- `black flarchitect/graphql/__init__.py flarchitect/core/architect.py tests/test_graphql.py`
- `ACCESS_SECRET_KEY=access REFRESH_SECRET_KEY=refresh pytest tests/test_graphql.py`


------
https://chatgpt.com/codex/tasks/task_e_689f05cd7c40832284d817d40eb482fe