### PR TITLE
feat(add-update-and-delete-mutations): feat(graphql): add update and delete mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ query {
 }
 ```
 
+Mutations allow you to create, update and delete records:
+
+```graphql
+mutation { create_item(name: "Foo") { id name } }
+mutation { update_item(id: 1, name: "Bar") { id name } }
+mutation { delete_item(id: 1) }
+```
+
 The [GraphQL demo](demo/graphql/README.md) contains ready-made models and sample queries to help you get started.
 
 Read about hiding and restoring records in the [soft delete section](docs/source/advanced_configuration.rst#soft-delete).

--- a/docs/source/graphql.rst
+++ b/docs/source/graphql.rst
@@ -22,12 +22,13 @@ The generated schema provides CRUD-style queries and mutations for each model.
 An ``all_items`` query returns every ``Item`` and a ``create_item`` mutation adds
 a new record.
 
-Example mutation
-~~~~~~~~~~~~~~~~
+Example create mutation
+~~~~~~~~~~~~~~~~~~~~~~~
 
-``create_schema_from_models`` automatically generates a ``create_<table>``
-mutation for each model. The mutation accepts all non-primary-key columns as
-arguments. The example below creates a new ``Item``:
+``create_schema_from_models`` automatically generates ``create_<table>``,
+``update_<table>`` and ``delete_<table>`` mutations for each model. The
+``create`` mutation accepts all non-primary-key columns as arguments. The
+example below creates a new ``Item``:
 
 .. code-block:: graphql
 
@@ -36,6 +37,33 @@ arguments. The example below creates a new ``Item``:
            id
            name
        }
+   }
+
+Example update mutation
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Updating a record requires the primary key and any columns to change. The
+following mutation updates the ``Item`` created above:
+
+.. code-block:: graphql
+
+   mutation {
+       update_item(id: 1, name: "Bar") {
+           id
+           name
+       }
+   }
+
+Example delete mutation
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Deletion requires only the primary key and returns a boolean flag indicating
+success:
+
+.. code-block:: graphql
+
+   mutation {
+       delete_item(id: 1)
    }
 
 Example query


### PR DESCRIPTION
## Summary
- generate update_ and delete_ mutations alongside create for GraphQL models
- document usage of update/delete mutations
- test update and delete GraphQL operations

## Testing
- `ruff check flarchitect/graphql/__init__.py tests/test_graphql.py --fix`
- `isort flarchitect/graphql/__init__.py tests/test_graphql.py`
- `black flarchitect/graphql/__init__.py tests/test_graphql.py`
- `pytest tests/test_graphql.py`


------
https://chatgpt.com/codex/tasks/task_e_689f05bc8988832292ce035a8acb4dc4