### PR TITLE
fix(rate-limit): allow memory backend without host

### DIFF
--- a/tests/test_rate_limit_services.py
+++ b/tests/test_rate_limit_services.py
@@ -27,6 +27,15 @@ class TestRateLimitServices:
 
         assert check_rate_services() == "redis://127.0.0.1:6379"
 
+    def test_memory_storage_uri_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``memory://`` URIs do not require a host and should be accepted."""
+
+        monkeypatch.setattr(
+            "flarchitect.utils.general.get_config_or_model_meta",
+            lambda key, default=None, model=None: "memory://",
+        )
+        assert check_rate_services() == "memory://"
+
     def test_returns_none_without_services(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- allow memory backend URIs without a host and validate missing scheme
- test rate limit service accepts `memory://`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f148d90d883229c3f52b6d89d3533