### PR TITLE
fix(utils): stabilise endpoint naming and rate service detection

### DIFF
--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -1396,9 +1396,21 @@ def endpoint_namer(
     if model_obj is None:
         raise ValueError("A model or schema with a Meta.model attribute is required")
 
-    case = get_config_or_model_meta(
+    case_raw = get_config_or_model_meta(
         "API_ENDPOINT_CASE", default="kebab", model=model_obj
     )
+    case = str(case_raw).lower()
+    valid_cases = {
+        "camel",
+        "pascal",
+        "snake",
+        "screaming_snake",
+        "kebab",
+        "screaming_kebab",
+    }
+    if case not in valid_cases:
+        case = "kebab"
+
     converted_name = convert_case(model_obj.__name__, case)
     pluralized_name = pluralize_last_word(converted_name)
     return convert_case(pluralized_name, case)


### PR DESCRIPTION
## Summary
- normalise API endpoint case names and fall back to kebab when configuration is invalid
- make rate limit backend auto-detection opt-in via `API_RATE_LIMIT_AUTODETECT`

## Testing
- `pytest tests/test_specs_utils.py tests/test_rate_limit_services.py tests/test_nested_schema_refs_case.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f27d5e98483228b6dae55dde4f781