### PR TITLE
refactor(rate-limit): allow dependency injection for rate limit checks

### DIFF
--- a/tests/test_rate_limit_services.py
+++ b/tests/test_rate_limit_services.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import importlib.util
-
 import pytest
 
 from flarchitect.utils.general import check_rate_prerequisites, check_rate_services
@@ -12,39 +10,27 @@ from flarchitect.utils.general import check_rate_prerequisites, check_rate_servi
 class TestRateLimitServices:
     """Validate rate limit storage detection and prerequisites."""
 
-    def test_returns_config_uri(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_config_uri(self) -> None:
         """Use configured storage URI when provided."""
 
-        # Provide a custom storage URI via configuration helper.
-        monkeypatch.setattr(
-            "flarchitect.utils.general.get_config_or_model_meta",
-            lambda key, default=None, model=None: "redis://127.0.0.1:6379",
-        )
-        monkeypatch.setattr(
-            "flarchitect.utils.general.check_rate_prerequisites",
-            lambda service: None,
+        assert (
+            check_rate_services(
+                config_getter=lambda *_, **__: "redis://127.0.0.1:6379",
+                prereq_checker=lambda _: None,
+            )
+            == "redis://127.0.0.1:6379"
         )
 
-        assert check_rate_services() == "redis://127.0.0.1:6379"
-
-    def test_memory_storage_uri_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_memory_storage_uri_allowed(self) -> None:
         """``memory://`` URIs do not require a host and should be accepted."""
 
-        monkeypatch.setattr(
-            "flarchitect.utils.general.get_config_or_model_meta",
-            lambda key, default=None, model=None: "memory://",
+        assert (
+            check_rate_services(config_getter=lambda *_, **__: "memory://")
+            == "memory://"
         )
-        assert check_rate_services() == "memory://"
 
-    def test_returns_none_without_services(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_returns_none_without_services(self) -> None:
         """Return ``None`` when no cache services are reachable."""
-
-        monkeypatch.setattr(
-            "flarchitect.utils.general.get_config_or_model_meta",
-            lambda key, default=None, model=None: None,
-        )
 
         class DummySocket:
             def __init__(self, *args, **kwargs) -> None:  # noqa: D401 - simple init
@@ -59,39 +45,32 @@ class TestRateLimitServices:
             def close(self) -> None:  # pragma: no cover
                 pass
 
-        monkeypatch.setattr(
-            "flarchitect.utils.general.socket.socket", lambda *a, **k: DummySocket()
+        assert (
+            check_rate_services(
+                config_getter=lambda *_, **__: None,
+                socket_factory=lambda *_, **__: DummySocket(),
+            )
+            is None
         )
 
-        assert check_rate_services() is None
-
-    def test_prerequisites_missing_dependency(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_prerequisites_missing_dependency(self) -> None:
         """Raise ``ImportError`` if required client library is absent."""
 
-        monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
         with pytest.raises(ImportError):
-            check_rate_prerequisites("Redis")
+            check_rate_prerequisites("Redis", find_spec=lambda name: None)
 
-    def test_invalid_storage_uri_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_invalid_storage_uri_raises(self) -> None:
         """Unsupported URI schemes raise a ``ValueError``."""
 
-        monkeypatch.setattr(
-            "flarchitect.utils.general.get_config_or_model_meta",
-            lambda key, default=None, model=None: "invalid://localhost",
-        )
         with pytest.raises(ValueError):
-            check_rate_services()
+            check_rate_services(
+                config_getter=lambda *_, **__: "invalid://localhost",
+            )
 
-    def test_missing_host_in_storage_uri_raises(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_missing_host_in_storage_uri_raises(self) -> None:
         """A storage URI without a host should raise ``ValueError``."""
 
-        monkeypatch.setattr(
-            "flarchitect.utils.general.get_config_or_model_meta",
-            lambda key, default=None, model=None: "redis://",
-        )
         with pytest.raises(ValueError):
-            check_rate_services()
+            check_rate_services(
+                config_getter=lambda *_, **__: "redis://",
+            )


### PR DESCRIPTION
## Summary
- refactor rate limit utilities to allow injecting config, prerequisite checks, and sockets
- replace monkeypatch usage in tests with direct dependency injection and verbosity control

## Testing
- `pytest tests/test_rate_limit_services.py tests/test_specs_utils.py tests/test_nested_schema_refs_case.py`

------
https://chatgpt.com/codex/tasks/task_e_689f34425b588322b6502ec94a41a156