### PR TITLE
feat(update-documentation-for-bumpwright-usage): docs(bumpwright): clarify version bump workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,9 @@ The package version is defined in `pyproject.toml` and exposed as `flarchitect._
 
 To publish a new release:
 
-1. Update the `version` field in `pyproject.toml` (for example with `hatch version patch`).
-2. Commit and push to `master`.
+1. Commit your feature or fix.
+2. Run `bumpwright auto --commit --tag` to let BumpWright calculate the next version and record it in a separate commit (and tag).
+3. Push both your feature commit and the bump commit (along with any tags) to `master`.
 
 Ensure the repository has a `PYPI_API_TOKEN` secret with an API token from PyPI.
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -19,6 +19,14 @@ FAQ
     Options are: camel, pascal, snake, kebab, screaming_kebab, screaming_snake
 
 
+.. dropdown:: When should I run BumpWright to bump the version?
+
+
+    Make your code changes and commit them first. Then run ``bumpwright auto --commit --tag`` to let BumpWright
+    determine the next version and record it in a separate commit (and optional tag). Finally, push both the
+    feature commit and the bump commit, along with any tags, to your remote repository.
+
+
 .. dropdown:: Can I block HTTP methods in my API?
 
 


### PR DESCRIPTION
## Summary
- document that code changes should be committed before running `bumpwright auto --commit --tag`
- note that the bump commit and tags should be pushed separately

## Testing
- `ruff check README.md docs/source/faq.rst` (fails: invalid syntax, non-Python files)
- `isort -v README.md docs/source/faq.rst`
- `black README.md docs/source/faq.rst` (fails: cannot parse non-Python files)
- `pytest` (fails: 61 errors during collection)

## Labels
- docs

------
https://chatgpt.com/codex/tasks/task_e_689f349d07a483228113bfd8790d6c4d