### PR TITLE
feat(investigate-inconsistent-outputs-of-bumpwright-commands): docs(bumpwright): clarify decide, bump, and auto commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ pytest
 
 The package version is defined in `pyproject.toml` and exposed as `flarchitect.__version__`. A GitHub Actions workflow automatically publishes to PyPI when the version changes on `master`.
 
+### BumpWright commands
+
+BumpWright ships with a few subcommands to help manage versions:
+
+- `bumpwright decide` inspects recent commits or API changes and reports the release type without touching any files.
+- `bumpwright bump` applies the version increment. Add `--dry-run` to preview the change without writing.
+- `bumpwright auto` combines both steps, deciding and bumping in one go. Useful when you simply want the version updated based on the current repository state.
+
 To publish a new release:
 
 1. Commit your feature or fix.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -26,6 +26,13 @@ FAQ
     determine the next version and record it in a separate commit (and optional tag). Finally, push both the
     feature commit and the bump commit, along with any tags, to your remote repository.
 
+.. dropdown:: What do the BumpWright commands do?
+
+    - ``bumpwright decide`` inspects your recent commits or API differences and reports the release type without
+      modifying any files.
+    - ``bumpwright bump`` increments the version. Add ``--dry-run`` to preview the change before writing.
+    - ``bumpwright auto`` combines deciding and bumping into a single command, ideal for most release workflows.
+
 
 .. dropdown:: Can I block HTTP methods in my API?
 


### PR DESCRIPTION
## Summary
- explain differences between `bumpwright decide`, `bumpwright bump`, and `bumpwright auto`
- document BumpWright usage in FAQ

## Testing
- `ruff check flarchitect/__init__.py`
- `isort --check-only README.md docs/source/faq.rst`
- `black --check flarchitect/__init__.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f54e955c083229903c17a5248bdfb