### PR TITLE
fix(release): tag bump to prevent duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ The package version is defined in `pyproject.toml` and exposed as `flarchitect._
 BumpWright ships with a few subcommands to help manage versions:
 
 - `bumpwright decide` inspects recent commits or API changes and reports the release type without touching any files.
-- `bumpwright bump` applies the version increment. Add `--dry-run` to preview the change without writing.
+- `bumpwright bump` applies the version increment. If no release is required, the command exits with "No version bump needed". Add `--dry-run` to preview the change without writing.
 - `bumpwright auto` combines both steps, deciding and bumping in one go. Useful when you simply want the version updated based on the current repository state.
 
 To publish a new release:

--- a/bumpwright.toml
+++ b/bumpwright.toml
@@ -1,0 +1,3 @@
+# BumpWright configuration to prevent automatic version bumps when no release is required.
+# No explicit bump level is defined; `bumpwright bump` will exit without changes
+# if `bumpwright decide` returns `None`.

--- a/flarchitect/utils/__init__.py
+++ b/flarchitect/utils/__init__.py
@@ -1,5 +1,9 @@
-"""Utility helpers for flarchitect."""
+"""Utility helpers for flarchitect.
 
+This subpackage aggregates small helper functions used across the project.
+"""
+
+from .release import bump_version_if_needed
 from .session import get_session
 
-__all__ = ["get_session"]
+__all__ = ["get_session", "bump_version_if_needed"]

--- a/flarchitect/utils/release.py
+++ b/flarchitect/utils/release.py
@@ -1,0 +1,64 @@
+"""Release helpers for BumpWright integration.
+
+This module wraps the ``bumpwright`` command-line tool to avoid accidental
+version bumps. The helper verifies whether a bump is required before applying
+it, returning ``None`` when no release is needed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+
+def bump_version_if_needed(
+    base: str | None = None,
+    head: str = "HEAD",
+    dry_run: bool = False,
+    tag: bool = True,
+) -> str | None:
+    """Bump project version only when BumpWright recommends a release.
+
+    The function first runs ``bumpwright decide``. If no bump level is
+    suggested, ``None`` is returned and no version files are touched. When a
+    level is suggested, ``bumpwright bump`` is executed with that level and the
+    new version is returned. By default a Git tag is created for the new
+    version to prevent subsequent invocations from repeating the bump.
+
+    Args:
+        base: Base git reference for comparison. When ``None``, BumpWright
+            selects the last release commit automatically.
+        head: Head git reference for comparison. Defaults to ``HEAD``.
+        dry_run: When ``True``, perform a dry run without modifying any files.
+        tag: When ``True`` and not a dry run, create a Git tag for the new
+            version.
+
+    Returns:
+        The new version string if a bump is applied; otherwise ``None``.
+
+    Raises:
+        subprocess.CalledProcessError: If either BumpWright command fails.
+    """
+
+    decide_cmd = ["bumpwright", "decide", "--format", "json"]
+    if base:
+        decide_cmd.extend(["--base", base])
+    if head:
+        decide_cmd.extend(["--head", head])
+    result = subprocess.run(decide_cmd, capture_output=True, text=True, check=True)
+    level = json.loads(result.stdout).get("level")
+    if level in (None, "None"):
+        return None
+
+    bump_cmd = ["bumpwright", "bump", "--level", str(level), "--format", "json"]
+    if base:
+        bump_cmd.extend(["--base", base])
+    if head:
+        bump_cmd.extend(["--head", head])
+    if dry_run:
+        bump_cmd.append("--dry-run")
+    elif tag:
+        bump_cmd.append("--tag")
+    bump_res = subprocess.run(bump_cmd, capture_output=True, text=True, check=True)
+    data = json.loads(bump_res.stdout)
+    return data.get("new_version")

--- a/tests/test_release_utils.py
+++ b/tests/test_release_utils.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import call, patch
+
+from flarchitect.utils.release import bump_version_if_needed
+
+
+def test_bump_version_if_needed_no_change() -> None:
+    """It should return ``None`` and avoid calling bump when no release is needed."""
+    decide_cp = subprocess.CompletedProcess([], 0, stdout='{"level": null}')
+    with patch(
+        "flarchitect.utils.release.subprocess.run", return_value=decide_cp
+    ) as run:
+        assert bump_version_if_needed() is None
+        run.assert_called_once_with(
+            ["bumpwright", "decide", "--format", "json"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+
+def test_bump_version_if_needed_with_change() -> None:
+    """It should apply a bump when a level is suggested."""
+    decide_cp = subprocess.CompletedProcess([], 0, stdout='{"level": "patch"}')
+    bump_cp = subprocess.CompletedProcess(
+        [],
+        0,
+        stdout='{"old_version": "0.1.0", "new_version": "0.1.1", "level": "patch"}',
+    )
+
+    def side_effect(cmd, capture_output, text, check):  # type: ignore[override]
+        if cmd[1] == "decide":
+            return decide_cp
+        if cmd[1] == "bump":
+            return bump_cp
+        raise AssertionError("Unexpected command")
+
+    with patch(
+        "flarchitect.utils.release.subprocess.run", side_effect=side_effect
+    ) as run:
+        assert bump_version_if_needed() == "0.1.1"
+        assert run.mock_calls == [
+            call(
+                ["bumpwright", "decide", "--format", "json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ),
+            call(
+                [
+                    "bumpwright",
+                    "bump",
+                    "--level",
+                    "patch",
+                    "--format",
+                    "json",
+                    "--tag",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            ),
+        ]
+
+
+def test_bump_version_if_needed_dry_run() -> None:
+    """It should omit tagging when performing a dry run."""
+    decide_cp = subprocess.CompletedProcess([], 0, stdout='{"level": "minor"}')
+    bump_cp = subprocess.CompletedProcess(
+        [],
+        0,
+        stdout='{"old_version": "0.1.0", "new_version": "0.2.0", "level": "minor"}',
+    )
+
+    def side_effect(cmd, capture_output, text, check):  # type: ignore[override]
+        if cmd[1] == "decide":
+            return decide_cp
+        if cmd[1] == "bump":
+            return bump_cp
+        raise AssertionError("Unexpected command")
+
+    with patch(
+        "flarchitect.utils.release.subprocess.run", side_effect=side_effect
+    ) as run:
+        assert bump_version_if_needed(dry_run=True) == "0.2.0"
+        assert run.mock_calls == [
+            call(
+                ["bumpwright", "decide", "--format", "json"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ),
+            call(
+                [
+                    "bumpwright",
+                    "bump",
+                    "--level",
+                    "minor",
+                    "--format",
+                    "json",
+                    "--dry-run",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            ),
+        ]


### PR DESCRIPTION
## Summary
- ensure conditional version bumps tag releases to avoid repeat bumps
- cover release helper with dry-run and tagging tests

## Testing
- `ruff check --fix flarchitect/utils/release.py tests/test_release_utils.py flarchitect/utils/__init__.py`
- `isort flarchitect/utils/release.py tests/test_release_utils.py flarchitect/utils/__init__.py`
- `black flarchitect/utils/release.py tests/test_release_utils.py flarchitect/utils/__init__.py`
- `pytest` *(fails: ModuleNotFoundError and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f59d3143c8322a553c067fbf62ade