### PR TITLE
fix(logging): remove duplicate verbosity assignment in Architect

### DIFF
--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -167,7 +167,6 @@ class Architect(AttributeInitializerMixin):
                 )
             else:
                 self.init_app(app, *args, **kwargs)
-                logger.verbosity_level = self.get_config("API_VERBOSITY_LEVEL", 0)
 
     @staticmethod
     def _is_reloader_start() -> bool:


### PR DESCRIPTION
## Summary
- remove redundant logger verbosity update in Architect.__init__

## Testing
- `pytest tests/test_logging_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a085c250f08322be6b37f79099fc6b