### PR TITLE
refactor(get_session-to-use-contextmanager): refactor(session): use context manager for database sessions

### DIFF
--- a/flarchitect/authentication/jwt.py
+++ b/flarchitect/authentication/jwt.py
@@ -251,15 +251,15 @@ def refresh_access_token(refresh_token: str) -> tuple[str, Any]:
 
     # Query the user by lookup_field and pk
     try:
-        user = (
-            get_session(usr_model_class)
-            .query(usr_model_class)
-            .filter(
-                getattr(usr_model_class, lookup_field) == lookup_value,
-                getattr(usr_model_class, pk_field) == pk_value,
+        with get_session(usr_model_class) as session:
+            user = (
+                session.query(usr_model_class)
+                .filter(
+                    getattr(usr_model_class, lookup_field) == lookup_value,
+                    getattr(usr_model_class, pk_field) == pk_value,
+                )
+                .one()
             )
-            .one()
-        )
     except NoResultFound as exc:
         raise CustomHTTPException(status_code=404, reason="User not found") from exc
 
@@ -311,15 +311,15 @@ def get_user_from_token(token: str, secret_key: str | None = None) -> Any:
 
     # Query the user by primary key or lookup field (like username)
     try:
-        user = (
-            get_session(usr_model_class)
-            .query(usr_model_class)
-            .filter(
-                getattr(usr_model_class, lookup_field) == payload[lookup_field],
-                getattr(usr_model_class, pk) == payload[pk],
+        with get_session(usr_model_class) as session:
+            user = (
+                session.query(usr_model_class)
+                .filter(
+                    getattr(usr_model_class, lookup_field) == payload[lookup_field],
+                    getattr(usr_model_class, pk) == payload[pk],
+                )
+                .one()
             )
-            .one()
-        )
     except NoResultFound as exc:
         raise CustomHTTPException(status_code=404, reason="User not found") from exc
 

--- a/flarchitect/authentication/token_store.py
+++ b/flarchitect/authentication/token_store.py
@@ -53,8 +53,7 @@ def store_refresh_token(
         user_lookup: User lookup field value as a string.
         expires_at: Token expiration timestamp.
     """
-    with _lock:
-        session = get_session(RefreshToken)
+    with _lock, get_session(RefreshToken) as session:
         _ensure_table(session)
         session.merge(
             RefreshToken(
@@ -76,10 +75,11 @@ def get_refresh_token(token: str) -> RefreshToken | None:
     Returns:
         RefreshToken | None: Stored refresh token or ``None`` if not found.
     """
-    session = get_session(RefreshToken)
-    _ensure_table(session)
-    session.expire_all()
-    return session.get(RefreshToken, token)
+    with get_session(RefreshToken) as session:
+        _ensure_table(session)
+        session.expire_all()
+        result = session.get(RefreshToken, token)
+    return result
 
 
 def delete_refresh_token(token: str) -> None:
@@ -88,8 +88,7 @@ def delete_refresh_token(token: str) -> None:
     Args:
         token: Encoded refresh token string.
     """
-    with _lock:
-        session = get_session(RefreshToken)
+    with _lock, get_session(RefreshToken) as session:
         _ensure_table(session)
         instance = session.get(RefreshToken, token)
         if instance is not None:

--- a/flarchitect/core/architect.py
+++ b/flarchitect/core/architect.py
@@ -680,10 +680,15 @@ class Architect(AttributeInitializerMixin):
         query = getattr(user_model, "query", None)
         if query is None:
             try:
-                session = get_session(user_model)
+                with get_session(user_model) as session:
+                    for usr in session.query(user_model).all():
+                        stored = getattr(usr, hash_field, None)
+                        if stored and getattr(usr, check_method)(token):
+                            set_current_user(usr)
+                            return True
             except Exception:
                 return False
-            query = session.query(user_model)
+            return False
 
         for usr in query.all():
             stored = getattr(usr, hash_field, None)


### PR DESCRIPTION
## Summary
- refactor session resolution to yield scoped sessions via context manager
- update session helpers and callers to use `with get_session(...):`
- test session helper ensures sessions are closed after use

## Testing
- `pytest tests/test_session_helper.py`
- `ruff check flarchitect/core/routes.py flarchitect/core/architect.py flarchitect/authentication/token_store.py flarchitect/authentication/jwt.py flarchitect/utils/session.py tests/test_session_helper.py`


------
https://chatgpt.com/codex/tasks/task_e_68a085aaf7548322bef80e5e0166c883