### PR TITLE
refactor(utils): replace pytz with datetime timezone

### DIFF
--- a/flarchitect/specs/utils.py
+++ b/flarchitect/specs/utils.py
@@ -4,10 +4,9 @@ import random
 import re
 from collections.abc import Callable
 from copy import deepcopy
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
-import pytz
 from marshmallow import Schema, fields
 from marshmallow_sqlalchemy.fields import Nested, Related, RelatedList
 from sqlalchemy.orm import DeclarativeBase
@@ -802,7 +801,7 @@ def generate_filter_examples(schema: Schema) -> str:
     Returns:
         str: Filter examples.
     """
-    now = datetime.now(pytz.utc)
+    now = datetime.now(timezone.utc)
     yesterday = now - timedelta(days=1)
     day_before_yesterday = yesterday - timedelta(days=1)
 

--- a/flarchitect/utils/response_helpers.py
+++ b/flarchitect/utils/response_helpers.py
@@ -1,9 +1,8 @@
 import time
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
-import pytz
 from flask import Response, current_app, g, jsonify
 
 from flarchitect.utils.config_helpers import get_config_or_model_meta, is_xml
@@ -82,7 +81,7 @@ def create_response(
             else "n/a"
         )
 
-    current_time_with_tz = datetime.now(pytz.utc).isoformat()
+    current_time_with_tz = datetime.now(timezone.utc).isoformat()
     data = {
         "api_version": current_app.config.get("API_VERSION"),
         "datetime": current_time_with_tz,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "marshmallow-sqlalchemy>=0.29.0",
     "numpy>=1.21.6",
     "pymongo>=4.7.3",
-    "pytz>=2024.1",
     "redis>=5.0.8",
     "requests>=2.31.0",
     "sqlalchemy-utils>=0.41.2",

--- a/tests/test_response_filters.py
+++ b/tests/test_response_filters.py
@@ -63,7 +63,9 @@ from flarchitect.utils.response_filters import _filter_response_data
         ),
     ],
 )
-def test_filter_response_data_removes_and_keeps_keys(monkeypatch: pytest.MonkeyPatch, config: dict[str, bool], expected_keys: set[str]) -> None:
+def test_filter_response_data_removes_and_keeps_keys(
+    monkeypatch: pytest.MonkeyPatch, config: dict[str, bool], expected_keys: set[str]
+) -> None:
     """Ensure ``_filter_response_data`` honors configuration switches.
 
     Args:
@@ -72,7 +74,7 @@ def test_filter_response_data_removes_and_keeps_keys(monkeypatch: pytest.MonkeyP
         expected_keys: Keys that should remain after filtering.
     """
     data: dict[str, Any] = {
-        "datetime": "2024-01-01T00:00:00Z",
+        "datetime": "2024-01-01T00:00:00+00:00",
         "api_version": "v1",
         "status_code": 200,
         "response_ms": 10,
@@ -83,7 +85,9 @@ def test_filter_response_data_removes_and_keeps_keys(monkeypatch: pytest.MonkeyP
         "payload": {"id": 1},
     }
 
-    def fake_get_config_or_model_meta(key: str, *_, default: Any | None = None, **__) -> Any:
+    def fake_get_config_or_model_meta(
+        key: str, *_, default: Any | None = None, **__
+    ) -> Any:
         """Return configuration override for the given key."""
         return config.get(key, default)
 


### PR DESCRIPTION
## Summary
- replace pytz usage with Python's timezone utilities
- drop unused pytz dependency
- normalize timestamp format in filter tests

## Testing
- `pytest` *(fails: test_nested_schema_refs_case.py::test_nested_schema_refs_follow_case[camel], test_specs_utils.py::test_endpoint_namer_accepts_model_and_schemas)*

------
https://chatgpt.com/codex/tasks/task_e_68a085c5747c8322aea65854988a8aec