### PR TITLE
feat(codex/extend-paginate_query-to-skip-count-ao0aw0): fix(database): skip duplicate pagination counts

### DIFF
--- a/tests/test_paginate_query.py
+++ b/tests/test_paginate_query.py
@@ -1,9 +1,11 @@
+from typing import Any
+
 import pytest
 
 from demo.basic_factory.basic_factory import create_app
 from demo.basic_factory.basic_factory.extensions import db
 from demo.basic_factory.basic_factory.models import Book
-from flarchitect.database.operations import paginate_query
+from flarchitect.database.operations import CrudService, paginate_query
 
 
 @pytest.fixture
@@ -19,3 +21,46 @@ def test_paginate_query_returns_paginated_query_and_default(app):
         paginated, default_size = paginate_query(query, page=1, items_per_page=1)
         assert len(paginated.items) == 1
         assert default_size == 20
+
+
+def test_crud_service_uses_single_count_for_pagination(app, monkeypatch):
+    """Ensure CrudService does not trigger an extra count during pagination."""
+
+    with app.app_context(), app.test_request_context("/books?page=1&limit=1"):
+        service = CrudService(Book, db.session)
+
+        count_calls: dict[str, int] = {"value": 0}
+        captured_kwargs: dict[str, Any] = {}
+        query_class = type(db.session.query(Book))
+
+        def fake_count(self):  # pragma: no cover - used for behavioural assertion only
+            count_calls["value"] += 1
+            return 7
+
+        class DummyPagination:
+            def __init__(self) -> None:
+                self.items = ["sentinel"]
+
+            def all(self) -> list[str]:
+                return self.items
+
+        def fake_paginate(
+            self,
+            page=None,
+            per_page=None,
+            error_out=None,
+            count=True,
+            **kwargs,
+        ):  # pragma: no cover - patched for assertions
+            captured_kwargs.update({"page": page, "per_page": per_page, "error_out": error_out, **kwargs})
+            captured_kwargs.setdefault("count", count)
+            return DummyPagination()
+
+        monkeypatch.setattr(query_class, "count", fake_count, raising=False)
+        monkeypatch.setattr(query_class, "paginate", fake_paginate, raising=False)
+
+        result = service.get_query({"page": 1, "limit": 1})
+
+        assert count_calls["value"] == 1
+        assert captured_kwargs.get("count") is False
+        assert result["total_count"] == 7


### PR DESCRIPTION
## Summary
- add an optional skip_count flag to paginate_query to support count-less pagination when available
- update CrudService to reuse its precomputed count and skip Flask-SQLAlchemy's internal count
- add a regression test ensuring only a single count call occurs during pagination

## Testing
- pytest tests/test_paginate_query.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d27ca7f23c83288fab8f9a9024a1d8